### PR TITLE
#20 feat: Typograpy 컴포넌트 추가

### DIFF
--- a/src/components/Common/Typograpy/Typograpy.tsx
+++ b/src/components/Common/Typograpy/Typograpy.tsx
@@ -1,0 +1,44 @@
+import { PropsWithChildren } from 'react';
+import * as Styled from './TypograpyStyle';
+
+type Headline = 'headline-1' | 'headline-2' | 'headline-3' | 'headline-4';
+type Subtitle = 'subtitle-1' | 'subtitle-2' | 'subtitle-3' | 'subtitle-4';
+type Body = 'body-1' | 'body-2';
+type Button = 'button-1' | 'button-2';
+
+export interface ITypograpyProps {
+  variant: Headline | Subtitle | Body | Button | 'caption' | 'overline';
+}
+
+const Typograpy = (props: PropsWithChildren<ITypograpyProps>) => {
+  const { variant, children } = props;
+
+  const paragraphVariants = [
+    'subtitle-1',
+    'subtitle-2',
+    'subtitle-3',
+    'subtitle-4',
+    'body-1',
+    'body-2',
+  ];
+  const spanVariants = ['button-1', 'button-2', 'caption', 'overline'];
+
+  return (
+    <>
+      {variant === 'headline-1' && <Styled.Headline1>{children}</Styled.Headline1>}
+      {variant === 'headline-2' && <Styled.Headline2>{children}</Styled.Headline2>}
+      {variant === 'headline-3' && <Styled.Headline3>{children}</Styled.Headline3>}
+      {variant === 'headline-4' && <Styled.Headline4>{children}</Styled.Headline4>}
+
+      {paragraphVariants.includes(variant) && (
+        <Styled.ParagraphElementStyle variant={variant}>{children}</Styled.ParagraphElementStyle>
+      )}
+
+      {spanVariants.includes(variant) && (
+        <Styled.SpanElementStyle variant={variant}>{children}</Styled.SpanElementStyle>
+      )}
+    </>
+  );
+};
+
+export default Typograpy;

--- a/src/components/Common/Typograpy/TypograpyStyle.ts
+++ b/src/components/Common/Typograpy/TypograpyStyle.ts
@@ -1,0 +1,116 @@
+import styled, { css } from 'styled-components';
+import { ITypograpyProps } from './Typograpy';
+
+export const Headline1 = styled.h1`
+  font-family: 'SUIT-Semibold';
+  font-size: 3.4rem;
+  line-height: 4.4rem;
+`;
+
+export const Headline2 = styled.h2`
+  font-family: 'SUIT-Semibold';
+  font-size: 2.8rem;
+  line-height: 3.8rem;
+`;
+
+export const Headline3 = styled.h3`
+  font-family: 'SUIT-Bold';
+  font-size: 2.4rem;
+  line-height: 3.4rem;
+`;
+
+export const Headline4 = styled.h4`
+  font-family: 'SUIT-Bold';
+  font-size: 2rem;
+  line-height: 3rem;
+`;
+
+export const ParagraphElementStyle = styled.p<ITypograpyProps>`
+  ${({ variant }) => {
+    return css`
+      ${getParagraphStyle(variant)};
+    `;
+  }}
+`;
+
+export const SpanElementStyle = styled.span<ITypograpyProps>`
+  ${({ variant }) => {
+    return css`
+      ${getSpanElementStyle(variant)};
+    `;
+  }}
+`;
+
+const getParagraphStyle = (variant: string) => {
+  switch (variant) {
+    case 'subtitle-1':
+      return css`
+        font-family: 'SUIT-Semibold';
+        font-size: 1.8rem;
+        line-height: 2.8rem;
+        letter-spacing: -0.25px;
+      `;
+    case 'subtitle-2':
+      return css`
+        font-family: 'SUIT-Semibold';
+        font-size: 1.6rem;
+        line-height: 2.4rem;
+      `;
+    case 'subtitle-3':
+      return css`
+        font-family: 'SUIT-Regular';
+        font-size: 1.6rem;
+        line-height: 2.2rem;
+      `;
+    case 'subtitle-4':
+      return css`
+        font-family: 'SUIT-Regular';
+        font-size: 1.6rem;
+        line-height: 2.2rem;
+        letter-spacing: -0.25px;
+      `;
+    case 'body-1':
+      return css`
+        font-family: 'SUIT-Regular';
+        font-size: 1.4rem;
+        line-height: 2rem;
+        letter-spacing: -0.25px;
+      `;
+    case 'body-2':
+      return css`
+        font-family: 'SUIT-Regular';
+        font-size: 1.2rem;
+        line-height: 1.8rem;
+        letter-spacing: -0.25px;
+      `;
+  }
+};
+
+const getSpanElementStyle = (variant: string) => {
+  switch (variant) {
+    case 'button-1':
+      return css`
+        font-family: 'SUIT-Medium';
+        font-size: 1.4rem;
+        line-height: 1.6rem;
+      `;
+    case 'button-2':
+      return css`
+        font-family: 'SUIT-Medium';
+        font-size: 1.2rem;
+        line-height: 1.6rem;
+      `;
+    case 'caption':
+      return css`
+        font-family: 'SUIT-Regular';
+        font-size: 1rem;
+        line-height: 1.6rem;
+      `;
+    case 'overline':
+      return css`
+        font-family: 'SUIT-Medium';
+        font-size: 1rem;
+        line-height: 0.2px;
+      `;
+  }
+};

--- a/src/components/Common/index.ts
+++ b/src/components/Common/index.ts
@@ -6,3 +6,4 @@ export { default as TextArea } from './Forms/TextArea/TextArea';
 export { default as ContainedBadge } from './Badge/ContainedBadge';
 export { default as OutlinedBadge } from './Badge/OutlinedBadge';
 export { default as SvgIcon } from './Svg/SvgIcon';
+export { default as Typograpy } from './Typograpy/Typograpy';

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -8,6 +8,7 @@ import {
   ContainedBadge,
   OutlinedBadge,
   SvgIcon,
+  Typograpy,
 } from '@components/Common';
 
 const Home: NextPage = () => {
@@ -51,6 +52,12 @@ const Home: NextPage = () => {
       <SvgIcon type="category-2" />
       <SvgIcon type="category-3" />
       <p>글로벌 폰트 테스트</p>
+      <Typograpy variant="headline-1">헤더-1</Typograpy>
+      <Typograpy variant="subtitle-3">서브헤더-3</Typograpy>
+      <Typograpy variant="body-2">바디-2</Typograpy>
+      <Button size="x-small" type="button">
+        <Typograpy variant="button-1">버튼-1</Typograpy>
+      </Button>
     </>
   );
 };


### PR DESCRIPTION
### Issue
- #20

### 작업 내용

<img width="138" alt="스크린샷 2022-06-08 오후 11 57 33" src="https://user-images.githubusercontent.com/75570915/172649217-d8a28bc5-c795-40a3-b2d6-fa640369bc0e.png">

<br />

- 사용 예시
```
<Typograpy variant="headline-1">헤더-1</Typograpy>
<Typograpy variant="subtitle-3">서브헤더-3</Typograpy>
<Typograpy variant="body-2">바디-2</Typograpy>
<Button size="x-small" type="button">
  <Typograpy variant="button-1">버튼-1</Typograpy>
</Button>
```

### 논의 사항
- N/A
