### PR TITLE
#36 style: 클래스 상세 페이지 텍스트 색상 수정

### DIFF
--- a/src/components/ClassDetail/ClassInfo/ClassInfo.tsx
+++ b/src/components/ClassDetail/ClassInfo/ClassInfo.tsx
@@ -8,7 +8,7 @@ const ClassInfo = () => {
     <Styled.ClassInfoContainer>
       <Styled.Section>
         <Typograpy variant="subtitle-2">클래스 소개</Typograpy>
-        <Typograpy variant="body-1">
+        <Typograpy variant="body-1" textColor="gray6B">
           프랑스어를 완전 처음 접하시는 분들을 위해 함께 커리큘럼을 짜드려요. 간단하게 알파벳 연습도
           해보려고 합니다.
         </Typograpy>
@@ -18,7 +18,9 @@ const ClassInfo = () => {
         <Typograpy variant="subtitle-2">가능한 시간</Typograpy>
         <Styled.AvailableTime>
           <Typograpy variant="button-1">5월 24일 (화)</Typograpy>
-          <Typograpy variant="body-2">오후 6:00 - 오후 7:00</Typograpy>
+          <Typograpy variant="body-2" textColor="gray6B">
+            오후 6:00 (3시간 수업)
+          </Typograpy>
         </Styled.AvailableTime>
       </Styled.Section>
 

--- a/src/components/ClassDetail/CoachProfile/CoachProfile.tsx
+++ b/src/components/ClassDetail/CoachProfile/CoachProfile.tsx
@@ -7,8 +7,10 @@ const CoachProfile = () => {
       <Styled.CoachProfileContainer>
         <Styled.CoachProfileImg src="abcd" />
         <Styled.CoachProfileContentWrapper>
-          <Typograpy variant="subtitle-4">하늘님</Typograpy>
-          <Typograpy variant="body-2">
+          <Typograpy variant="subtitle-4" textColor="gray44">
+            하늘님
+          </Typograpy>
+          <Typograpy variant="body-2" textColor="gray44">
             프랑스에서 1년 동안 유학한 경험이 있어요. 다시 공부를 시작할 겸 해서 클래스를 열어보려
             합니다. 프랑스에서 1년 동안 유학한 경험이 있어요.
           </Typograpy>

--- a/src/components/ClassDetail/Guideline/Guideline.tsx
+++ b/src/components/ClassDetail/Guideline/Guideline.tsx
@@ -19,11 +19,17 @@ const Guideline = () => {
   ];
   return (
     <Styled.GuidelineContainer>
-      <Typograpy variant="subtitle-2">안내 사항</Typograpy>
+      <Typograpy variant="subtitle-2" textColor="gray44">
+        안내 사항
+      </Typograpy>
       {GUIDELINES.map(({ question, answer }) => (
         <Styled.QAContainer key={question}>
-          <Typograpy variant="body-1">{question}</Typograpy>
-          <Typograpy variant="body-1">{answer}</Typograpy>
+          <Typograpy variant="body-1" textColor="indigo">
+            {question}
+          </Typograpy>
+          <Typograpy variant="body-1" textColor="gray6B">
+            {answer}
+          </Typograpy>
         </Styled.QAContainer>
       ))}
     </Styled.GuidelineContainer>

--- a/src/components/ClassDetail/Guideline/GuidelineStyle.ts
+++ b/src/components/ClassDetail/Guideline/GuidelineStyle.ts
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 export const GuidelineContainer = styled.div`
   padding: 2.4rem;
   background-color: ${theme.color.gray['F7']};
+  margin-bottom: 10rem;
 
   & > :first-child {
     margin-bottom: 2.4rem;

--- a/src/components/ClassDetail/HowToUse/HowToUse.tsx
+++ b/src/components/ClassDetail/HowToUse/HowToUse.tsx
@@ -12,11 +12,15 @@ const HowToUse = () => {
   ];
   return (
     <Styled.Container>
-      <Typograpy variant="subtitle-2">이용 방법</Typograpy>
+      <Typograpy variant="subtitle-2" textColor="gray44">
+        이용 방법
+      </Typograpy>
       {INSTRUCTIONS.map(({ idx, text }) => (
         <Styled.Wrapper key={idx}>
           <Typograpy variant="subtitle-4">{idx}.</Typograpy>
-          <Typograpy variant="body-1">{text}</Typograpy>
+          <Typograpy variant="body-1" textColor="gray6B">
+            {text}
+          </Typograpy>
         </Styled.Wrapper>
       ))}
     </Styled.Container>


### PR DESCRIPTION
### Issue
- #36

### 작업 내용
<p align="center">
<img width="342" alt="스크린샷 2022-06-22 오후 4 35 32" src="https://user-images.githubusercontent.com/55427367/174971647-1519d0de-cacb-4e74-8786-b0888a62e645.png"><img width="337" alt="스크린샷 2022-06-22 오후 4 36 40" src="https://user-images.githubusercontent.com/55427367/174971628-94e8a960-1c56-43a3-b4bb-9479ca0b465a.png">
</p>


- 클래스 상세 페이지 텍스트 색상 수정

### 논의 사항
- 
