### PR TITLE
#38 feat: 클래스 상세 페이지 안내사항 추가 및 클래스 태그를 감싸는 컨테이너 생성

### DIFF
--- a/src/components/ClassDetail/ClassInfo/ClassInfo.tsx
+++ b/src/components/ClassDetail/ClassInfo/ClassInfo.tsx
@@ -32,7 +32,10 @@ const ClassInfo = () => {
 
       <Styled.Section>
         <Typograpy variant="subtitle-2">클래스 태그</Typograpy>
-        <ContainedBadge type="keyword">#프랑스어</ContainedBadge>
+        <Styled.ClassTag>
+          <ContainedBadge type="keyword">#기초</ContainedBadge>
+          <ContainedBadge type="keyword">#프랑스어회화</ContainedBadge>
+        </Styled.ClassTag>
       </Styled.Section>
     </Styled.ClassInfoContainer>
   );

--- a/src/components/ClassDetail/ClassInfo/ClassInfoStyle.ts
+++ b/src/components/ClassDetail/ClassInfo/ClassInfoStyle.ts
@@ -33,6 +33,7 @@ export const Section = styled.section`
 export const AvailableTime = styled.div`
   display: flex;
   align-items: center;
+  margin-bottom: 1.4rem;
 
   & > :first-child {
     margin-right: 2rem;
@@ -50,4 +51,12 @@ export const ClassImg = styled.img`
   height: 15rem;
   margin-right: 1.2rem;
   border-radius: 0.8rem;
+`;
+
+export const ClassTag = styled.div`
+  display: flex;
+
+  & > * {
+    margin-right: 0.6rem;
+  }
 `;

--- a/src/components/ClassDetail/Guideline/Guideline.tsx
+++ b/src/components/ClassDetail/Guideline/Guideline.tsx
@@ -16,6 +16,11 @@ const Guideline = () => {
       question: '볼은 언제 차감되나요?',
       answer: '코치가 매칭을 수락한 이후 차감됩니다.',
     },
+    {
+      question: '클래스는 어떤 방식으로 진행되나요?',
+      answer:
+        '매칭 완료 이후 카카오톡 ID를 전달해드려요. \n 카카오톡으로 코치와 함께 수업 방식을 정해보세요.',
+    },
   ];
   return (
     <Styled.GuidelineContainer>

--- a/src/components/ClassDetail/Guideline/GuidelineStyle.ts
+++ b/src/components/ClassDetail/Guideline/GuidelineStyle.ts
@@ -13,6 +13,7 @@ export const GuidelineContainer = styled.div`
 
 export const QAContainer = styled.div`
   margin-bottom: 2.4rem;
+  white-space: pre-line;
 
   & > :first-child {
     margin-bottom: 0.8rem;


### PR DESCRIPTION
### Issue
- #38

### 작업 내용
![image](https://user-images.githubusercontent.com/55427367/175231079-6316b969-ff30-49b3-9dc2-3ac3eca49301.png)
![image](https://user-images.githubusercontent.com/55427367/175231106-224611bf-6e8d-4d38-a29d-c3cc08607aa2.png)

- 안내사항 문구 추가
- 클래스 태그가 여러개가 됐을 때의 디자인을 고려하여 감싸는 flex container box 생성

### 논의 사항
- 
