### PR TITLE
#16 feat: 코치 프로필 상세 페이지 레이아웃

### DIFF
--- a/src/components/Common/Button/TextMore/TextMoreButton.tsx
+++ b/src/components/Common/Button/TextMore/TextMoreButton.tsx
@@ -1,3 +1,4 @@
+import Typograpy from '@components/Common/Typograpy/Typograpy';
 import * as Styled from './TextMoreButtonStyle';
 
 interface ITextMoreButtonProps {
@@ -5,7 +6,13 @@ interface ITextMoreButtonProps {
 }
 
 const TextMoreButton = ({ _onClick }: ITextMoreButtonProps) => {
-  return <Styled.TextMoreButtonStyle onClick={_onClick}>더 보기</Styled.TextMoreButtonStyle>;
+  return (
+    <Styled.TextMoreButtonStyle onClick={_onClick}>
+      <Typograpy variant="button-2" textColor="gray6B">
+        더 보기
+      </Typograpy>
+    </Styled.TextMoreButtonStyle>
+  );
 };
 
 export default TextMoreButton;

--- a/src/components/Common/Button/TextMore/TextMoreButtonStyle.ts
+++ b/src/components/Common/Button/TextMore/TextMoreButtonStyle.ts
@@ -1,5 +1,7 @@
+import Theme from '@styles/theme';
 import styled from 'styled-components';
 
 export const TextMoreButtonStyle = styled.button`
   text-decoration: underline;
+  text-decoration-color: ${Theme.color.gray['6B']};
 `;

--- a/src/components/Common/Typograpy/TypograpyStyle.ts
+++ b/src/components/Common/Typograpy/TypograpyStyle.ts
@@ -67,9 +67,10 @@ const getParagraphStyle = (variant: string) => {
       `;
     case 'subtitle-4':
       return css`
-        font-family: 'SUIT-Regular';
-        font-size: 1.6rem;
-        line-height: 2.2rem;
+        font-family: 'SUIT-Semibold';
+        font-size: 1.4rem;
+        font-weight: 600;
+        line-height: 2rem;
         letter-spacing: -0.25px;
       `;
     case 'body-1':

--- a/src/components/Profile/ClassReview/ClassReview.tsx
+++ b/src/components/Profile/ClassReview/ClassReview.tsx
@@ -1,17 +1,30 @@
-import { Typograpy } from '@components/Common';
+import { SvgIcon, Typograpy } from '@components/Common';
+import { useState } from 'react';
 import * as Styled from './ClassReviewStyle';
 import Review from './Review';
 
 const ClassReview = () => {
+  const [endIdx, setEndIdx] = useState(0);
+
+  const toggleReviewList = () => {
+    setEndIdx(endIdx + 2);
+  };
+
   return (
     <Styled.ClassReviewContainer>
       <Typograpy variant="subtitle-1">플레이어 후기</Typograpy>
-      {/* <Styled.NoReview>
+      <Styled.NoReview>
         <Typograpy variant="body-1" textColor="gray8F">
           플레이어 후기가 아직 없어요.
         </Typograpy>
-      </Styled.NoReview> */}
+      </Styled.NoReview>
       <Review />
+      <Styled.ShowMore onClick={toggleReviewList}>
+        <Typograpy variant="subtitle-4" textColor="gray6B">
+          더보기
+        </Typograpy>
+        <SvgIcon type="chevron-down" />
+      </Styled.ShowMore>
     </Styled.ClassReviewContainer>
   );
 };

--- a/src/components/Profile/ClassReview/ClassReview.tsx
+++ b/src/components/Profile/ClassReview/ClassReview.tsx
@@ -1,15 +1,17 @@
 import { Typograpy } from '@components/Common';
 import * as Styled from './ClassReviewStyle';
+import Review from './Review';
 
 const ClassReview = () => {
   return (
     <Styled.ClassReviewContainer>
       <Typograpy variant="subtitle-1">플레이어 후기</Typograpy>
-      <Styled.NoReview>
+      {/* <Styled.NoReview>
         <Typograpy variant="body-1" textColor="gray8F">
           플레이어 후기가 아직 없어요.
         </Typograpy>
-      </Styled.NoReview>
+      </Styled.NoReview> */}
+      <Review />
     </Styled.ClassReviewContainer>
   );
 };

--- a/src/components/Profile/ClassReview/ClassReview.tsx
+++ b/src/components/Profile/ClassReview/ClassReview.tsx
@@ -1,0 +1,17 @@
+import { Typograpy } from '@components/Common';
+import * as Styled from './ClassReviewStyle';
+
+const ClassReview = () => {
+  return (
+    <Styled.ClassReviewContainer>
+      <Typograpy variant="subtitle-1">플레이어 후기</Typograpy>
+      <Styled.NoReview>
+        <Typograpy variant="body-1" textColor="gray8F">
+          플레이어 후기가 아직 없어요.
+        </Typograpy>
+      </Styled.NoReview>
+    </Styled.ClassReviewContainer>
+  );
+};
+
+export default ClassReview;

--- a/src/components/Profile/ClassReview/ClassReviewStyle.ts
+++ b/src/components/Profile/ClassReview/ClassReviewStyle.ts
@@ -60,3 +60,11 @@ export const Contents = styled.div`
     margin-bottom: 0.6rem;
   }
 `;
+
+export const ShowMore = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 8.8rem;
+  pointer: cursor;
+`;

--- a/src/components/Profile/ClassReview/ClassReviewStyle.ts
+++ b/src/components/Profile/ClassReview/ClassReviewStyle.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+import Theme from '@styles/theme';
+
+export const ClassReviewContainer = styled.div`
+  margin-top: 4.8rem;
+`;
+
+export const NoReview = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 31.2rem;
+  height: 12rem;
+  margin-top: 0.8rem;
+  padding: 5rem 1.2rem;
+  border: 0.2rem dashed ${Theme.color.gray['EF']};
+  border-radius: 1rem;
+`;

--- a/src/components/Profile/ClassReview/ClassReviewStyle.ts
+++ b/src/components/Profile/ClassReview/ClassReviewStyle.ts
@@ -15,3 +15,48 @@ export const NoReview = styled.div`
   border: 0.2rem dashed ${Theme.color.gray['EF']};
   border-radius: 1rem;
 `;
+
+export const ReviewWrapper = styled.div`
+  margin-top: 2.6rem;
+`;
+
+export const ProfileImg = styled.img`
+  width: 4rem;
+  height: 4rem;
+  margin-right: 1rem;
+`;
+
+export const Profile = styled.div`
+  display: flex;
+  margin-bottom: 1.2rem;
+`;
+
+export const ProfileWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 1.6rem;
+
+  & > * {
+    margin-bottom: 0.7rem;
+  }
+`;
+
+export const NameDate = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-bottom: 0.2rem;
+
+  & > :first-child {
+    margin-right: 0.6rem;
+  }
+`;
+
+export const Contents = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  & > :first-child {
+    margin-bottom: 0.6rem;
+  }
+`;

--- a/src/components/Profile/ClassReview/Review.tsx
+++ b/src/components/Profile/ClassReview/Review.tsx
@@ -1,0 +1,36 @@
+import { TextMoreButton, Typograpy } from '@components/Common';
+import * as Styled from './ClassReviewStyle';
+
+const Review = () => {
+  const handleTextMore = () => {
+    console.log();
+  };
+  return (
+    <Styled.ReviewWrapper>
+      <Styled.Profile>
+        <Styled.ProfileImg src={`/img/profile.png`} />
+        <div>
+          <Styled.NameDate>
+            <Typograpy variant="subtitle-4">민희진</Typograpy>
+            <Typograpy variant="body-2" textColor="gray8F">
+              2022년 5월 8일
+            </Typograpy>
+          </Styled.NameDate>
+          <Typograpy variant="body-2" textColor="gray44">
+            프랑스어
+          </Typograpy>
+        </div>
+      </Styled.Profile>
+      <Styled.Contents>
+        <Typograpy variant="body-2" textColor="gray6B">
+          모바일에서는 최대 3줄까지 노출이 됩니다. 더 많아질 경우 더보기를 붙입니다. 모바일에서는
+          최대 3줄까지 노출이 됩니다. 더 많아질 경우 더보기를 붙입니다 이렇게붙여주세요 더보기를
+          붙입니다 이렇게 붙...
+        </Typograpy>
+        <TextMoreButton _onClick={handleTextMore} />
+      </Styled.Contents>
+    </Styled.ReviewWrapper>
+  );
+};
+
+export default Review;

--- a/src/components/Profile/ClassReview/Review.tsx
+++ b/src/components/Profile/ClassReview/Review.tsx
@@ -1,10 +1,20 @@
 import { TextMoreButton, Typograpy } from '@components/Common';
+import { useState } from 'react';
 import * as Styled from './ClassReviewStyle';
 
 const Review = () => {
-  const handleTextMore = () => {
-    console.log();
+  const LENGTH = 110;
+  const text =
+    '모바일에서는 최대 3줄까지 노출이 됩니다. 더 많아질 경우 더보기를 붙입니다. 모바일에서는 최대 3줄까지 노출이 됩니다. 더 많아질 경우 더보기를 붙입니다. 모바일에서는 최대 3줄까지 노출이 됩니다. 더 많아질 경우 더보기를 붙입니다. 모바일에서는 최대 3줄까지 노출이 됩니다. 더 많아질 경우 더보기를 붙입니다. 모바일에서는 최대 3줄까지 노출이 됩니다. 더 많아질 경우 더보기를 붙입니다.';
+
+  const [review, setReview] = useState(text.slice(0, LENGTH) + '...');
+  const [isLong, setIsLong] = useState(false);
+
+  const toggleTextMore = () => {
+    setReview(text);
+    setIsLong(!isLong);
   };
+
   return (
     <Styled.ReviewWrapper>
       <Styled.Profile>
@@ -23,11 +33,9 @@ const Review = () => {
       </Styled.Profile>
       <Styled.Contents>
         <Typograpy variant="body-2" textColor="gray6B">
-          모바일에서는 최대 3줄까지 노출이 됩니다. 더 많아질 경우 더보기를 붙입니다. 모바일에서는
-          최대 3줄까지 노출이 됩니다. 더 많아질 경우 더보기를 붙입니다 이렇게붙여주세요 더보기를
-          붙입니다 이렇게 붙...
+          {review}
         </Typograpy>
-        <TextMoreButton _onClick={handleTextMore} />
+        {!isLong && <TextMoreButton _onClick={toggleTextMore} />}
       </Styled.Contents>
     </Styled.ReviewWrapper>
   );

--- a/src/components/Profile/Introduction/Introduction.tsx
+++ b/src/components/Profile/Introduction/Introduction.tsx
@@ -1,13 +1,12 @@
 import { Typograpy } from '@components/Common';
 import * as Styled from './IntroductionStyle';
-import theme from '@styles/theme';
 
 const Introduction = () => {
   return (
     <Styled.IntroContainer>
       <Typograpy variant="subtitle-1">소개</Typograpy>
       <Styled.IntroWrapper>
-        <Typograpy variant="body-2" textColor={`${theme.color.gray['6B']}`}>
+        <Typograpy variant="body-2" textColor="gray6B">
           프랑스에서 1년 동안 유학한 경험이 있어요. 다시 공부를 시작할 겸 해서 클래스를 열어보려
           합니다. 프랑스에서 1년 동안 유학한 경험이 있어요. 다시 공부를 시작할 겸 해서 클래스를
           열어보려 합니다. 프랑스에서 1년 동안 유학한 경험이 있어요. 다시 공부를 시작할 겸 해서

--- a/src/components/Profile/ProfileHeader/ProfileHeader.tsx
+++ b/src/components/Profile/ProfileHeader/ProfileHeader.tsx
@@ -4,37 +4,42 @@ import Link from 'next/link';
 
 const ProfileHeader = () => {
   const isCoach = true;
+
   return (
     <Styled.ProfileContainer>
       <Styled.ProfileImg src={`/img/profile.png`} />
       <Styled.ProfileWrapper>
         <Typograpy variant="subtitle-1">유지민</Typograpy>
+
         <Styled.PlayerType>
           <ContainedBadge type="player">플레이어</ContainedBadge>
           {isCoach && <ContainedBadge type="coach">코치</ContainedBadge>}
         </Styled.PlayerType>
+
         {isCoach && (
-          <Styled.ProfileLink>
+          <Styled.IconWrapper>
             <SvgIcon type="k_class" size={18} />
             <Typograpy variant="subtitle-4">운영중인 클래스 2개</Typograpy>
-          </Styled.ProfileLink>
+          </Styled.IconWrapper>
         )}
+
         {isCoach && (
-          <Styled.ProfileLink>
+          <Styled.IconWrapper>
             <SvgIcon type="review" size={18} />
             <Typograpy variant="subtitle-4">후기 2개</Typograpy>
-          </Styled.ProfileLink>
+          </Styled.IconWrapper>
         )}
-        <Styled.ProfileLink>
+
+        <Styled.IconWrapper>
           <SvgIcon type="link" size={18}></SvgIcon>
-          <Typograpy variant="body-1" textColor="gray44">
-            <Link href={'https://www.knowlly.com/'} passHref>
-              <a target="_blank" rel="noopener noreferrer">
+          <Link href={'https://www.knowlly.com/'} passHref>
+            <a target="_blank" rel="noopener noreferrer">
+              <Typograpy variant="body-1" textColor="gray44">
                 www.knowly.com
-              </a>
-            </Link>
-          </Typograpy>
-        </Styled.ProfileLink>
+              </Typograpy>
+            </a>
+          </Link>
+        </Styled.IconWrapper>
       </Styled.ProfileWrapper>
     </Styled.ProfileContainer>
   );

--- a/src/components/Profile/ProfileHeader/ProfileHeader.tsx
+++ b/src/components/Profile/ProfileHeader/ProfileHeader.tsx
@@ -1,17 +1,33 @@
 import { ContainedBadge, SvgIcon, Typograpy } from '@components/Common';
 import * as Styled from './ProfileHeaderStyle';
-import theme from '@styles/theme';
 import Link from 'next/link';
+
 const ProfileHeader = () => {
+  const isCoach = true;
   return (
     <Styled.ProfileContainer>
       <Styled.ProfileImg src={`/img/profile.png`} />
       <Styled.ProfileWrapper>
         <Typograpy variant="subtitle-1">유지민</Typograpy>
-        <ContainedBadge type="player">플레이어</ContainedBadge>
+        <Styled.PlayerType>
+          <ContainedBadge type="player">플레이어</ContainedBadge>
+          {isCoach && <ContainedBadge type="coach">코치</ContainedBadge>}
+        </Styled.PlayerType>
+        {isCoach && (
+          <Styled.ProfileLink>
+            <SvgIcon type="k_class" size={18} />
+            <Typograpy variant="subtitle-4">운영중인 클래스 2개</Typograpy>
+          </Styled.ProfileLink>
+        )}
+        {isCoach && (
+          <Styled.ProfileLink>
+            <SvgIcon type="review" size={18} />
+            <Typograpy variant="subtitle-4">후기 2개</Typograpy>
+          </Styled.ProfileLink>
+        )}
         <Styled.ProfileLink>
           <SvgIcon type="link" size={18}></SvgIcon>
-          <Typograpy textColor={`${theme.color.gray['44']}`} variant="body-1">
+          <Typograpy variant="body-1" textColor="gray44">
             <Link href={'https://www.knowlly.com/'} passHref>
               <a target="_blank" rel="noopener noreferrer">
                 www.knowly.com
@@ -23,4 +39,5 @@ const ProfileHeader = () => {
     </Styled.ProfileContainer>
   );
 };
+
 export default ProfileHeader;

--- a/src/components/Profile/ProfileHeader/ProfileHeaderStyle.ts
+++ b/src/components/Profile/ProfileHeader/ProfileHeaderStyle.ts
@@ -20,6 +20,14 @@ export const ProfileWrapper = styled.div`
   }
 `;
 
+export const PlayerType = styled.div`
+  display: flex;
+
+  & > :first-child {
+    margin-right: 0.4rem;
+  }
+`;
+
 export const ProfileLink = styled.div`
   display: flex;
   align-items: flex-end;

--- a/src/components/Profile/ProfileHeader/ProfileHeaderStyle.ts
+++ b/src/components/Profile/ProfileHeader/ProfileHeaderStyle.ts
@@ -28,7 +28,7 @@ export const PlayerType = styled.div`
   }
 `;
 
-export const ProfileLink = styled.div`
+export const IconWrapper = styled.div`
   display: flex;
   align-items: flex-end;
   &>: first-child {

--- a/src/components/Profile/index.ts
+++ b/src/components/Profile/index.ts
@@ -1,2 +1,3 @@
 export { default as ProfileHeader } from './ProfileHeader/ProfileHeader';
 export { default as Introduction } from './Introduction/Introduction';
+export { default as ClassReview } from './ClassReview/ClassReview';

--- a/src/pages/profile/[id].tsx
+++ b/src/pages/profile/[id].tsx
@@ -1,12 +1,13 @@
 import type { NextPage } from 'next';
 import { Layout } from '@components/Common';
-import { Introduction, ProfileHeader } from '@components/Profile';
+import { ClassReview, Introduction, ProfileHeader } from '@components/Profile';
 
 const Profile: NextPage = () => {
   return (
     <Layout>
       <ProfileHeader />
       <Introduction />
+      <ClassReview />
     </Layout>
   );
 };


### PR DESCRIPTION
### Issue
- #16

### 작업 내용
![image](https://user-images.githubusercontent.com/55427367/175276315-da657ed1-d4cc-4d1e-a302-168c4bd5506c.png)

- 코치일 때 프로필 상세 페이지 레이아웃 생성
- 텍스트 더보기의 경우 110자를 기준으로 설정

### 논의 사항
- 텍스트 스타일 subtitle-4의 폰트 설정이 달라 수정했습니다.
