### PR TITLE
#43 feat: 테스트 서버 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/web-test-and-deploy-dev.yml
+++ b/.github/workflows/web-test-and-deploy-dev.yml
@@ -1,0 +1,84 @@
+name: WEB - Test and Deploy - dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Test scenario tags'
+  push:
+    branches:
+      - develop
+env:
+  DEPLOYMENT_NAME: knowlly-web-dev-deployment # Add your deployment name here.
+  IMAGE: knowlly-web
+jobs:
+  deployment-web:
+    name: WEB 빌드, 푸쉬 후 개발에 배포
+    runs-on: ubuntu-latest
+    steps:
+      - name: 소스코드 체크아웃
+        uses: actions/checkout@v2
+
+      - name: SHA 업데이트
+        run: echo $GITHUB_SHA > $GITHUB_WORKSPACE/_meta
+
+      - name: 이미지 태그 준비
+        id: get-tag
+        run: |
+          tag=$(echo $GITHUB_SHA | head -c7)
+          echo "::set-output name=tag::$tag"
+      - name: 도커 캐싱 준비
+        uses: docker/setup-buildx-action@v1
+
+      - name: 도커 레이어 캐싱
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: 도커 로그인
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+
+      - name: 컨테이너 이미지 빌드 및 이미지 푸쉬
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: docker.io/${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE }}:${{ steps.get-tag.outputs.tag }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: 캐시 삭제
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      - name: 배포파일 업데이트
+        run: TAG=${{ steps.get-tag.outputs.tag }} && sed -i 's|<IMAGE>|docker.io/${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE }}:'${TAG}'|' $GITHUB_WORKSPACE/deployment/deployment-dev.yml
+
+      - name: 환경변수 치환 후 최종 배포 파일 생성
+        uses: danielr1996/envsubst-action@1.0.0
+        with:
+          input: deployment/deployment-dev.yml
+          output: deploy.yml
+
+      - name: 클러스터에 배포
+        uses: NaLDo627/kubectl@master
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA_DEV }}
+        with:
+          args: apply -f deploy.yml
+
+      - name: 배포 확인
+        uses: NaLDo627/kubectl@master
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA_DEV }}
+        with:
+          args: '"rollout status deployment/${{ env.DEPLOYMENT_NAME }}"'

--- a/deployment/deployment-dev.yml
+++ b/deployment/deployment-dev.yml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: knowlly-web-dev-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: knowlly-web-dev
+  template:
+    metadata:
+      labels:
+        app: knowlly-web-dev
+    spec:
+      containers:
+        - name: knowlly-web-dev
+          image: <IMAGE>
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "512m"
+            limits:
+              memory: "512Mi"
+              cpu: "512m"
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 5


### PR DESCRIPTION
### Issue
- #43 

### 작업 내용
- develop 브랜치가 push 될때마다, 테스트 서버에 배포되도록 github workflow 작성
    - 테스트 웹 서버 URL : http://knowllydev-web.hkpark.net/
- Repository Secret에 각각 아래의 시크릿 값 추가
    - `DOCKER_USERNAME` : dockerhub 이름
    - `DOCKER_PASSWORD` : dockerhub 비밀번호
    - `KUBE_CONFIG_DATA_DEV` : 쿠버네티스 배포 설정값

### 논의 사항
- Repository Secret의 `DOCKER_USERNAME`, `DOCKER_PASSWORD` 는 임의로 제 것으로 해두었으나, 본인 것으로 대체하셔도 됩니다.
    - 단, `KUBE_CONFIG_DATA_DEV`는 건들면 안됩니다!
- 이후 Dockerfile의 스크립트 최적화가 필요합니다. #45 
    - 현재 Dockfile의 Entrypoint가 개발용 명령어인 `npm run dev` 으로 되어있는데, 이는 개발용 도구 때문에 배포 환경에서는 맞지 않습니다. (리소스 이슈)
    - `npm run build` 후 serve 하는 방향으로. static하게 동작하도록 수정 요청 드립니다. ([관련 링크](https://appdevelopmaster.tistory.com/506))