### PR TITLE
#73 feat: 등록된 클래스 목록에서 상세페이지로 라우팅 연결

### DIFF
--- a/src/components/Home/LectureCard/LectureCard.tsx
+++ b/src/components/Home/LectureCard/LectureCard.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import { ContainedBadge } from '@components/Common';
 import { ILectureInfoData } from '@/types/lectureInfo';
 import * as Styled from './LectureCardStyle';
@@ -9,20 +10,24 @@ interface ILectureCardProps {
 
 const LectureCard = ({ lectureData }: ILectureCardProps) => {
   return (
-    <Styled.LectureCardContainer>
-      <Styled.LectureImageWrapper>
-        <Image src="/img/profile.png" width={88} height={88} />
-      </Styled.LectureImageWrapper>
-      <div>
-        <Styled.LectureIntroduce variant="subtitle-2">
-          {lectureData.introduce}
-        </Styled.LectureIntroduce>
-        <Styled.LectureCoachName variant="body-2" textColor="gray8F">
-          {lectureData.coach.user.username}
-        </Styled.LectureCoachName>
-        <ContainedBadge type="category">뱃지</ContainedBadge>
-      </div>
-    </Styled.LectureCardContainer>
+    <li>
+      <Link href={`/lecture-detail/${lectureData.id}`}>
+        <Styled.LectureCardContainer>
+          <Styled.LectureImageWrapper>
+            <Image src="/img/profile.png" width={88} height={88} />
+          </Styled.LectureImageWrapper>
+          <div>
+            <Styled.LectureIntroduce variant="subtitle-2">
+              {lectureData.introduce}
+            </Styled.LectureIntroduce>
+            <Styled.LectureCoachName variant="body-2" textColor="gray8F">
+              {lectureData.coach.user.username}
+            </Styled.LectureCoachName>
+            <ContainedBadge type="category">뱃지</ContainedBadge>
+          </div>
+        </Styled.LectureCardContainer>
+      </Link>
+    </li>
   );
 };
 

--- a/src/components/Home/LectureCard/LectureCardStyle.ts
+++ b/src/components/Home/LectureCard/LectureCardStyle.ts
@@ -1,7 +1,7 @@
 import styled, { css } from 'styled-components';
 import { Typograpy } from '@components/Common';
 
-export const LectureCardContainer = styled.li`
+export const LectureCardContainer = styled.a`
   ${({ theme }) => {
     const { color } = theme;
 

--- a/src/types/lectureInfo.ts
+++ b/src/types/lectureInfo.ts
@@ -5,6 +5,7 @@ export interface ILectureInfo {
 }
 
 export interface ILectureInfoData {
+  id: number;
   topic: string;
   introduce: string;
   price: number;


### PR DESCRIPTION
### Issue
- #73 

### 작업 내용
- 최근 등록된 클래스 목록, 카테고리 클래스 목록, 검색된 클래스 목록 등에서 클래스 클릭 시 클래스 상세 페이지로 이동
- 상세 페이지에 대한 데이터 prefetch를 위해 next/link 사용

### 논의 사항
- N/A
