### PR TITLE
#72 feat: 매칭 신청서 작성 기능 구현

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,5 @@
 import { IReview } from '@/types/review';
+import { IMatching } from '@/types/matching';
 import createAxiosWithTestToken from './customAxios';
 
 class HttpAPI {
@@ -15,6 +16,14 @@ class HttpAPI {
 
   async postReview(coachId: number, review: IReview) {
     const { data } = await createAxiosWithTestToken('').post(`review/coach/${coachId}`, review);
+    return data;
+  }
+
+  async postMatchingForm(scheduleId: number, matchingForm: IMatching) {
+    const { data } = await createAxiosWithTestToken('').post(
+      `review/coach/${scheduleId}`,
+      matchingForm
+    );
     return data;
   }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,7 +21,7 @@ class HttpAPI {
 
   async postMatchingForm(scheduleId: number, matchingForm: IMatching) {
     const { data } = await createAxiosWithTestToken('').post(
-      `review/coach/${scheduleId}`,
+      `form/lecture/${scheduleId}`,
       matchingForm
     );
     return data;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,5 @@
 import { IReview } from '@/types/review';
-import { IMatching } from '@/types/matching';
+import { IPlayerMatchingForm } from '@/types/matching';
 import createAxiosWithTestToken from './customAxios';
 
 class HttpAPI {
@@ -19,7 +19,7 @@ class HttpAPI {
     return data;
   }
 
-  async postMatchingForm(scheduleId: number, matchingForm: IMatching) {
+  async postMatchingForm(scheduleId: number, matchingForm: IPlayerMatchingForm) {
     const { data } = await createAxiosWithTestToken('').post(
       `form/lecture/${scheduleId}`,
       matchingForm

--- a/src/components/Matching/FirstStep/FirstStep.tsx
+++ b/src/components/Matching/FirstStep/FirstStep.tsx
@@ -2,25 +2,18 @@ import { Typograpy } from '@components/Common';
 import { PageLayout } from '@components/Common/Layout';
 import { useSelect } from '@hooks';
 import { matchingStepState, playerMatchingState } from '@recoil/matching/atoms';
+import { ILectureDetailSchedule } from '@/types/lectureDetail';
 import React from 'react';
 import { useRecoilState } from 'recoil';
 import ScheduleBox from '../ScheduleBox/ScheduleBox';
 import * as Styled from './FirstStepStyle';
 
-// API 연동 전 임시 Array Type
-export interface ISchedule {
-  id: number;
-  day: string;
-  time: string;
+interface ILectureScheduleProps {
+  lectureSchedule: ILectureDetailSchedule[];
 }
 
-const FirstStep = () => {
-  const schedules = [
-    { id: 0, day: '6월 24일 (화)', time: '오후 6:00 (3시간 수업)' },
-    { id: 1, day: '5월 24일 (화)', time: '오후 6:00 (3시간 수업)' },
-  ];
-
-  const { selectedIndex, setSelectedIndex } = useSelect(schedules);
+const FirstStep = ({ lectureSchedule }: ILectureScheduleProps) => {
+  const { selectedIndex, setSelectedIndex } = useSelect(lectureSchedule);
   const [matchingStep, setMatchingStep] = useRecoilState(matchingStepState);
   const [playerMatching, setPlayerMatching] = useRecoilState(playerMatchingState);
 
@@ -38,7 +31,7 @@ const FirstStep = () => {
           코치가 보낸 일정 중 한가지만 선택해주세요.
         </Typograpy>
       </Styled.TextWrapper>
-      {schedules.map((schedule) => (
+      {lectureSchedule.map((schedule) => (
         <ScheduleBox
           key={schedule.id}
           schedule={schedule}

--- a/src/components/Matching/FirstStep/FirstStep.tsx
+++ b/src/components/Matching/FirstStep/FirstStep.tsx
@@ -20,7 +20,7 @@ const FirstStep = ({ lectureSchedule }: ILectureScheduleProps) => {
   const handleScheduleClick = (id: number) => {
     setSelectedIndex(id);
     setTimeout(() => setMatchingStep(matchingStep + 1), 300);
-    setPlayerMatching({ ...playerMatching, schedule: 'schedule' }); //TODO: 일정 parsing
+    setPlayerMatching({ ...playerMatching, scheduleId: id }); //TODO: 일정 parsing
   };
 
   return (

--- a/src/components/Matching/ScheduleBox/ScheduleBox.tsx
+++ b/src/components/Matching/ScheduleBox/ScheduleBox.tsx
@@ -1,9 +1,10 @@
 import { SvgIcon, Typograpy } from '@components/Common';
+import { ILectureDetailSchedule } from '@/types/lectureDetail';
+import { formatDate, formatTime, getLectureTime } from '@utils';
 import React from 'react';
-import { ISchedule } from '../FirstStep/FirstStep';
 import * as Styled from './ScheduleBoxStyle';
 interface IScheduleBoxProps {
-  schedule: ISchedule;
+  schedule: ILectureDetailSchedule;
   isSelected: boolean;
   _onClick: () => void;
 }
@@ -14,9 +15,10 @@ const ScheduleBox = (props: IScheduleBoxProps) => {
     <>
       <Styled.Container>
         <Styled.TextWrapper>
-          <Typograpy variant="button-1">{schedule.day}</Typograpy>
+          <Typograpy variant="button-1">{formatDate(schedule.startAt)}</Typograpy>
           <Typograpy variant="body-2" textColor="gray6B">
-            {schedule.time}
+            {formatTime(schedule.startAt)} ({getLectureTime(schedule.startAt, schedule.endAt)}시간
+            수업)
           </Typograpy>
         </Styled.TextWrapper>
         <div onClick={_onClick}>

--- a/src/components/Matching/SecondStep/SecondStep.tsx
+++ b/src/components/Matching/SecondStep/SecondStep.tsx
@@ -15,7 +15,7 @@ const SecondStep = () => {
   };
 
   const handleNextButtonClick = () => {
-    nextStep();
+    //nextStep();
     setPlayerMatching({ ...playerMatching, introduction: introduction });
     //TODO: 매칭신청서 POST 요청
   };

--- a/src/components/Matching/SecondStep/SecondStep.tsx
+++ b/src/components/Matching/SecondStep/SecondStep.tsx
@@ -1,27 +1,24 @@
 import { Button, TextArea, Typograpy } from '@components/Common';
-import { matchingStepState, playerMatchingState } from '@recoil/matching/atoms';
+import { playerMatchingState } from '@recoil/matching/atoms';
 import React, { useState } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import * as Styled from './SecondStepStyle';
 import { PageLayout } from '@components/Common/Layout';
+import useApplyMatching from '@hooks/matching/useApplyMatching';
 
 const SecondStep = () => {
-  const [introduction, setIntroduction] = useState('');
-  const [playerMatching, setPlayerMatching] = useRecoilState(playerMatchingState);
-  const [matchingStep, setMatchingStep] = useRecoilState(matchingStepState);
+  const [content, setContent] = useState('');
+  const playerMatching = useRecoilValue(playerMatchingState);
 
-  const handleIntroductionText = (value: string) => {
-    setIntroduction(value);
+  const handleIntroductionContent = (value: string) => {
+    setContent(value);
   };
+
+  const applyMatching = useApplyMatching(playerMatching.scheduleId);
 
   const handleNextButtonClick = () => {
-    //nextStep();
-    setPlayerMatching({ ...playerMatching, introduction: introduction });
-    //TODO: 매칭신청서 POST 요청
-  };
-
-  const nextStep = () => {
-    setMatchingStep(matchingStep + 1);
+    const payload = { scheduleId: playerMatching.scheduleId, content: content };
+    applyMatching.mutate(payload);
   };
 
   return (
@@ -33,7 +30,7 @@ const SecondStep = () => {
             간단한 소개와 궁금한 내용을 적어주세요.
           </Typograpy>
         </Styled.TextWrapper>
-        <TextArea value={introduction} maxLength={500} _onInputEntered={handleIntroductionText} />
+        <TextArea value={content} maxLength={500} _onInputEntered={handleIntroductionContent} />
       </PageLayout>
       <Styled.ButtonWrapper>
         <Typograpy variant="body-2" textColor="primary">
@@ -42,7 +39,7 @@ const SecondStep = () => {
         <Typograpy variant="body-2" textColor="primary">
           신중하게 선택해주세요.
         </Typograpy>
-        <Button _onClick={handleNextButtonClick} disabled={introduction.length === 0}>
+        <Button _onClick={handleNextButtonClick} disabled={content.length === 0}>
           매칭 신청 완료하기
         </Button>
       </Styled.ButtonWrapper>

--- a/src/hooks/matching/useApplyMatching.ts
+++ b/src/hooks/matching/useApplyMatching.ts
@@ -1,0 +1,20 @@
+import api from '@api';
+import { IMatching } from '@/types/matching';
+import { useMutation } from 'react-query';
+import { matchingStepState } from '@recoil/matching/atoms';
+import { useRecoilState } from 'recoil';
+
+const useApplyMatching = (scheduleId: number) => {
+  const [matchingStep, setMatchingStep] = useRecoilState(matchingStepState);
+  const { mutate } = useMutation(
+    (matchingForm: IMatching) => api.postMatchingForm(scheduleId, matchingForm),
+    {
+      onSuccess: () => {
+        setMatchingStep(matchingStep + 1);
+      },
+    }
+  );
+  return { mutate };
+};
+
+export default useApplyMatching;

--- a/src/hooks/matching/useApplyMatching.ts
+++ b/src/hooks/matching/useApplyMatching.ts
@@ -1,5 +1,5 @@
 import api from '@api';
-import { IMatching } from '@/types/matching';
+import { IMatchingForm } from '@/types/matching';
 import { useMutation } from 'react-query';
 import { matchingStepState } from '@recoil/matching/atoms';
 import { useRecoilState } from 'recoil';
@@ -7,7 +7,7 @@ import { useRecoilState } from 'recoil';
 const useApplyMatching = (scheduleId: number) => {
   const [matchingStep, setMatchingStep] = useRecoilState(matchingStepState);
   const { mutate } = useMutation(
-    (matchingForm: IMatching) => api.postMatchingForm(scheduleId, matchingForm),
+    (matchingForm: IMatchingForm) => api.postMatchingForm(scheduleId, matchingForm),
     {
       onSuccess: () => {
         setMatchingStep(matchingStep + 1);

--- a/src/pages/matching/index.tsx
+++ b/src/pages/matching/index.tsx
@@ -5,14 +5,24 @@ import { matchingStepState } from '@recoil/matching/atoms';
 import { NextPage } from 'next';
 import { useRecoilValue } from 'recoil';
 import { IndicatorWrapper } from '@components/Matching/MatchingStyle';
+import useLectureDetail from '@hooks/lecture/useLectureDetail';
+import { useRouter } from 'next/router';
 
 const Matching: NextPage = () => {
   const matchingStep = useRecoilValue(matchingStepState);
 
+  const router = useRouter();
+  const lectureId = Number(router.query.id);
+
+  const lectureDetail = useLectureDetail(lectureId);
+  const lectureSchedule = lectureDetail.data.lectures.filter(
+    (lecture) => lecture.state == 'ON_GOING'
+  );
+
   const setPage = (step: number) => {
     switch (step) {
       case 0:
-        return <FirstStep />;
+        return <FirstStep lectureSchedule={lectureSchedule} />;
       case 1:
         return <SecondStep />;
       case 2:

--- a/src/recoil/matching/atoms.ts
+++ b/src/recoil/matching/atoms.ts
@@ -6,14 +6,14 @@ export const matchingStepState = atom({
 });
 
 interface IPlayerMatching {
-  schedule: string;
-  introduction: string;
+  scheduleId: number;
+  content: string;
 }
 
 export const playerMatchingState = atom<IPlayerMatching>({
   key: 'playerMatching',
   default: {
-    schedule: '',
-    introduction: '',
+    scheduleId: 0,
+    content: '',
   },
 });

--- a/src/recoil/matching/atoms.ts
+++ b/src/recoil/matching/atoms.ts
@@ -1,16 +1,12 @@
+import { IPlayerMatchingState } from '@/types/matching';
 import { atom } from 'recoil';
 
-export const matchingStepState = atom({
+export const matchingStepState = atom<number>({
   key: 'matchingStep',
   default: 0,
 });
 
-interface IPlayerMatching {
-  scheduleId: number;
-  content: string;
-}
-
-export const playerMatchingState = atom<IPlayerMatching>({
+export const playerMatchingState = atom<IPlayerMatchingState>({
   key: 'playerMatching',
   default: {
     scheduleId: 0,

--- a/src/types/matching.ts
+++ b/src/types/matching.ts
@@ -1,0 +1,3 @@
+export interface IMatching {
+  content: string;
+}

--- a/src/types/matching.ts
+++ b/src/types/matching.ts
@@ -1,3 +1,8 @@
-export interface IMatching {
+export interface IPlayerMatchingForm {
+  content: string;
+}
+
+export interface IPlayerMatchingState {
+  scheduleId: number;
   content: string;
 }


### PR DESCRIPTION
### Issue
- #72

### 작업 내용
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/55427367/178148613-2933645f-95f6-4155-8b70-8407acd25f07.gif)
(아직 API 변한거 적용을 안했더니 카테고리가 안뜨네요 ,, )
- 유저가 클래스에 매칭을 신청할 수 있는 기능 구현

### 논의 사항
- `playerMatching`이라는 recoil state가 불필요해보여 추후 리팩토링을 하면서 수정을 할 예정입니다.
- 페이지를 부드럽게 이동하는 애니메이션 적용이 필요해보입니다.
