### PR TITLE
#88 매칭 신청서 페이지 배포 오류 수정 

### DIFF
--- a/src/components/LectureDetail/CoachProfile/CoachProfile.tsx
+++ b/src/components/LectureDetail/CoachProfile/CoachProfile.tsx
@@ -12,7 +12,7 @@ const CoachProfile = ({ coachProfile }: ICoachProfileProps) => {
   return (
     <>
       <Styled.CoachProfileContainer>
-        <Styled.CoachProfileImg src="abcd" />
+        <Styled.CoachProfileImg src={coach.userImgUrl} />
         <Styled.CoachProfileContentWrapper>
           <Typograpy variant="subtitle-4" textColor="gray44">
             {coach.username}

--- a/src/components/Matching/FirstStep/FirstStep.tsx
+++ b/src/components/Matching/FirstStep/FirstStep.tsx
@@ -12,7 +12,7 @@ interface ILectureScheduleProps {
   lectureSchedule: ILectureDetailSchedule[];
 }
 
-const FirstStep = ({ lectureSchedule }: ILectureScheduleProps) => {
+const FirstStep = ({ lectureSchedule = [] }: ILectureScheduleProps) => {
   const { selectedIndex, setSelectedIndex } = useSelect(lectureSchedule);
   const [matchingStep, setMatchingStep] = useRecoilState(matchingStepState);
   const [playerMatching, setPlayerMatching] = useRecoilState(playerMatchingState);

--- a/src/hooks/lecture/useLectureDetail.ts
+++ b/src/hooks/lecture/useLectureDetail.ts
@@ -4,8 +4,12 @@ import queryKeys from '@react-query/keys';
 import { ILectureDetail } from '@/types/lectureDetail';
 
 const useLectureDetail = (lectureId: number): ILectureDetail => {
-  const { data: lectureDetail } = useQuery([queryKeys.lectureDetail, lectureId], () =>
-    api.fetchLectureDetail(lectureId)
+  const { data: lectureDetail } = useQuery(
+    [queryKeys.lectureDetail, lectureId],
+    () => api.fetchLectureDetail(lectureId),
+    {
+      enabled: !!lectureId,
+    }
   );
 
   return lectureDetail;

--- a/src/pages/matching/index.tsx
+++ b/src/pages/matching/index.tsx
@@ -2,14 +2,11 @@ import { SvgIcon } from '@components/Common';
 import { PageLayout } from '@components/Common/Layout';
 import { FirstStep, LastStep, SecondStep, Title } from '@components/Matching';
 import { matchingStepState } from '@recoil/matching/atoms';
-import { GetServerSideProps, NextPage } from 'next';
+import { NextPage } from 'next';
 import { useRecoilValue } from 'recoil';
 import { IndicatorWrapper } from '@components/Matching/MatchingStyle';
 import useLectureDetail from '@hooks/lecture/useLectureDetail';
 import { useRouter } from 'next/router';
-import { dehydrate, QueryClient } from 'react-query';
-import queryKeys from '@react-query/keys';
-import api from '@api';
 
 const Matching: NextPage = () => {
   const matchingStep = useRecoilValue(matchingStepState);
@@ -66,18 +63,4 @@ const Matching: NextPage = () => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const lectureId = context.query.id;
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery([queryKeys.lectureDetail, Number(lectureId)], () =>
-    api.fetchLectureDetail(Number(lectureId))
-  );
-
-  const dehydratedState = dehydrate(queryClient);
-
-  return {
-    props: { dehydratedState: dehydratedState },
-  };
-};
 export default Matching;


### PR DESCRIPTION
### Issue
- #88

### 작업 내용
- 매칭신청서 새로고침 시 undefined 뜨는 오류 수정

### 논의 사항
-  매칭신청서 페이지에서 새로고침을 하게 되면 클래스 상세 페이지에서 받은 query가 inactive 상태로 바뀝니다. SSR로 해결하긴 했는데 혹시 더 좋은 방법 생각나시면 추천 부탁드립니다 ..
