### PR TITLE
#81 feat: 운영클래스 매칭 신청인의 매칭 신청서 페이지 구현

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -36,6 +36,11 @@ class HttpAPI {
     );
     return data;
   }
+
+  async fetchCoachLectureForm(formId: string) {
+    const { data } = await createAxiosWithTestToken(`form`).get(`/${formId}`);
+    return data;
+  }
 }
 
 const api = new HttpAPI();

--- a/src/components/CoachLecture/MatchingPopup/MatchingPopup.tsx
+++ b/src/components/CoachLecture/MatchingPopup/MatchingPopup.tsx
@@ -1,0 +1,33 @@
+import { Button, Typograpy } from '@components/Common';
+import { formatDate } from '@utils';
+import * as Styled from './MatchingPopupStyle';
+
+interface IMatchingPopupProps {
+  expirationDate: string;
+}
+
+const MatchingPopup = ({ expirationDate }: IMatchingPopupProps) => {
+  return (
+    <Styled.MatchingPopupContainer>
+      <Styled.MatchingExpirationDate>
+        <Typograpy variant="subtitle-2">{formatDate(expirationDate, 'year')}</Typograpy>
+        <Typograpy variant="body-1">까지 응답 가능</Typograpy>
+      </Styled.MatchingExpirationDate>
+      <Styled.MatchingAlertMessage>
+        <Typograpy variant="body-2" textColor="gray6B">
+          기간 내 매칭을 수락하지 않으면 자동으로 거절돼요.
+        </Typograpy>
+      </Styled.MatchingAlertMessage>
+      <Styled.MatchingButtonWrapper>
+        <Button variant="outlined" size="small" type="button">
+          매칭 거절하기
+        </Button>
+        <Button variant="contained" size="small" type="button">
+          매칭 수락하기
+        </Button>
+      </Styled.MatchingButtonWrapper>
+    </Styled.MatchingPopupContainer>
+  );
+};
+
+export default MatchingPopup;

--- a/src/components/CoachLecture/MatchingPopup/MatchingPopupStyle.ts
+++ b/src/components/CoachLecture/MatchingPopup/MatchingPopupStyle.ts
@@ -1,0 +1,44 @@
+import styled, { css } from 'styled-components';
+
+export const MatchingPopupContainer = styled.div`
+  ${({ theme }) => {
+    const { primary } = theme.color;
+
+    return css`
+      position: fixed;
+      left: 0;
+      bottom: 0;
+      width: 100%;
+      height: 17rem;
+      padding: 2rem 0 2.4rem;
+      background-color: ${primary.light};
+    `;
+  }}
+`;
+
+export const MatchingPopupText = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 0 2.4rem;
+  width: 100%;
+`;
+
+export const MatchingExpirationDate = styled(MatchingPopupText)`
+  margin-bottom: 0.4rem;
+
+  & > p:nth-child(1) {
+    margin-right: 0.2rem;
+  }
+`;
+
+export const MatchingAlertMessage = styled(MatchingPopupText)``;
+
+export const MatchingButtonWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 2.4rem;
+
+  & > button:nth-child(1) {
+    margin-right: 1.2rem;
+  }
+`;

--- a/src/components/CoachLecture/PlayerInfo/PlayerInfo.tsx
+++ b/src/components/CoachLecture/PlayerInfo/PlayerInfo.tsx
@@ -1,0 +1,19 @@
+import { PropsWithChildren } from 'react';
+import * as Styled from './PlayerInfoStyle';
+
+interface IPlayerInfoProps {
+  title: string;
+}
+
+const PlayerInfo = ({ children, title }: PropsWithChildren<IPlayerInfoProps>) => {
+  return (
+    <Styled.PlayerInfoContainer>
+      <Styled.PlayerInfoTitle variant="subtitle-2" textColor="gray44">
+        {title}
+      </Styled.PlayerInfoTitle>
+      {children}
+    </Styled.PlayerInfoContainer>
+  );
+};
+
+export default PlayerInfo;

--- a/src/components/CoachLecture/PlayerInfo/PlayerInfoStyle.ts
+++ b/src/components/CoachLecture/PlayerInfo/PlayerInfoStyle.ts
@@ -1,0 +1,10 @@
+import { Typograpy } from '@components/Common';
+import styled from 'styled-components';
+
+export const PlayerInfoContainer = styled.section`
+  margin-top: 4rem;
+`;
+
+export const PlayerInfoTitle = styled(Typograpy)`
+  margin-bottom: 0.8rem;
+`;

--- a/src/components/CoachLecture/PlayerSchedule/PlayerSchedule.tsx
+++ b/src/components/CoachLecture/PlayerSchedule/PlayerSchedule.tsx
@@ -1,0 +1,22 @@
+import { Typograpy } from '@components/Common';
+import { formatDate } from '@utils';
+import * as Styled from './PlayerScheduleStyle';
+
+interface IPlayerScheduleProps {
+  schedules: string;
+}
+
+const PlayerSchedule = ({ schedules }: IPlayerScheduleProps) => {
+  return (
+    <>
+      <Typograpy variant="body-2" textColor="gray8F">
+        해당 일정에 클래스를 여는 것이 가능하다면 수락해주세요.
+      </Typograpy>
+      <Styled.PlayerUserSchedule>
+        <Typograpy variant="subtitle-4">{formatDate(schedules)}</Typograpy>
+      </Styled.PlayerUserSchedule>
+    </>
+  );
+};
+
+export default PlayerSchedule;

--- a/src/components/CoachLecture/PlayerSchedule/PlayerScheduleStyle.ts
+++ b/src/components/CoachLecture/PlayerSchedule/PlayerScheduleStyle.ts
@@ -1,0 +1,16 @@
+import styled, { css } from 'styled-components';
+
+export const PlayerUserSchedule = styled.div`
+  ${({ theme }) => {
+    const { gray } = theme.color;
+
+    return css`
+      width: 31.2rem;
+      height: 6.4rem;
+      margin-top: 2rem;
+      padding: 1.2rem 1.6rem;
+      border: 1px solid ${gray['CC']};
+      border-radius: 0.8rem;
+    `;
+  }}
+`;

--- a/src/components/CoachLecture/PlayerUser/PlayerUser.tsx
+++ b/src/components/CoachLecture/PlayerUser/PlayerUser.tsx
@@ -1,0 +1,27 @@
+import { IPlayerUser } from '@/types/coachLecture';
+import { Image, Typograpy } from '@components/Common';
+import * as Styled from './PlayerUserStyle';
+
+interface IPlayerUserProps {
+  userInfo: IPlayerUser;
+}
+
+const PlayerUser = ({ userInfo }: IPlayerUserProps) => {
+  return (
+    <Styled.PlayerUserContainer>
+      <Styled.PlayerUserProfileWrapper>
+        <Image
+          type="form-profile"
+          src={userInfo.userImgUrl}
+          alt={`${userInfo.username}님의 프로필 이미지`}
+        />
+        <Typograpy variant="subtitle-4">{userInfo.username}</Typograpy>
+      </Styled.PlayerUserProfileWrapper>
+      <Typograpy variant="body-1" textColor="gray6B">
+        {userInfo.intro}
+      </Typograpy>
+    </Styled.PlayerUserContainer>
+  );
+};
+
+export default PlayerUser;

--- a/src/components/CoachLecture/PlayerUser/PlayerUserStyle.ts
+++ b/src/components/CoachLecture/PlayerUser/PlayerUserStyle.ts
@@ -1,0 +1,23 @@
+import styled, { css } from 'styled-components';
+
+export const PlayerUserContainer = styled.div`
+  ${({ theme }) => {
+    const { gray } = theme.color;
+
+    return css`
+      padding: 1.4rem 0rem 1.6rem 0rem;
+      border-top: 1px solid ${gray['EF']};
+      border-bottom: 1px solid ${gray['EF']};
+    `;
+  }}
+`;
+
+export const PlayerUserProfileWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.2rem;
+
+  & > p:nth-child(2) {
+    margin-left: 0.8rem;
+  }
+`;

--- a/src/components/CoachLecture/index.ts
+++ b/src/components/CoachLecture/index.ts
@@ -1,0 +1,4 @@
+export { default as MatchingPopup } from './MatchingPopup/MatchingPopup';
+export { default as PlayerInfo } from './PlayerInfo/PlayerInfo';
+export { default as PlayerUser } from './PlayerUser/PlayerUser';
+export { default as PlayerSchedule } from './PlayerSchedule/PlayerSchedule';

--- a/src/components/Common/Image/Image.tsx
+++ b/src/components/Common/Image/Image.tsx
@@ -2,7 +2,13 @@ import { default as NextImage, ImageLoader } from 'next/image';
 import { PropsWithChildren } from 'react';
 
 interface IImageProps {
-  type: 'lecture-list' | 'lecture-detail' | 'profile' | 'coach-profile' | 'review-profile';
+  type:
+    | 'lecture-list'
+    | 'lecture-detail'
+    | 'profile'
+    | 'form-profile'
+    | 'coach-profile'
+    | 'review-profile';
   src: string;
   alt?: string;
   priority?: boolean;
@@ -21,6 +27,8 @@ const handleImgWidth = (type: string) => {
       return 150;
     case 'profile':
       return 60;
+    case 'form-profile':
+      return 32;
     case 'coach-profile':
       return 48;
     case 'review-profile':

--- a/src/hooks/coachLecture/useMatchingForm.ts
+++ b/src/hooks/coachLecture/useMatchingForm.ts
@@ -1,0 +1,18 @@
+import { IPlayerUserForm } from '@/types/coachLecture';
+import api from '@api';
+import queryKeys from '@react-query/keys';
+import { useQuery } from 'react-query';
+
+interface IUseMatchingForm {
+  matchingFormData: IPlayerUserForm;
+}
+
+const useMatchingForm = (formId: string): IUseMatchingForm => {
+  const { data: matchingFormData } = useQuery([queryKeys.coachLecture, formId], () =>
+    api.fetchCoachLectureForm(formId)
+  );
+
+  return { matchingFormData: matchingFormData.data };
+};
+
+export default useMatchingForm;

--- a/src/pages/coach-lecture/[id].tsx
+++ b/src/pages/coach-lecture/[id].tsx
@@ -1,0 +1,47 @@
+import { GetServerSideProps, NextPage } from 'next';
+import { useRouter } from 'next/router';
+import { Typograpy } from '@components/Common';
+import { PageLayout } from '@components/Common/Layout';
+import { MatchingPopup, PlayerInfo, PlayerUser, PlayerSchedule } from '@components/CoachLecture';
+import useMatchingForm from '@hooks/coachLecture/useMatchingForm';
+import api from '@api';
+import { dehydrate, QueryClient } from 'react-query';
+import queryKeys from '@react-query/keys';
+
+const CoachLecturePage: NextPage = () => {
+  const router = useRouter();
+  const formId = router.query.id;
+
+  const { matchingFormData } = useMatchingForm(formId as string);
+
+  return (
+    <PageLayout isSpacing start={1}>
+      <Typograpy variant="headline-3">매칭 신청서</Typograpy>
+      <PlayerInfo title="플레이어 정보">
+        <PlayerUser userInfo={matchingFormData?.user} />
+      </PlayerInfo>
+      <PlayerInfo title="플레이어의 코멘트">
+        <Typograpy variant="body-1" textColor="gray6B">
+          {matchingFormData?.content}
+        </Typograpy>
+      </PlayerInfo>
+      <PlayerInfo title="플레이어가 보낸 일정">
+        <PlayerSchedule schedules={matchingFormData?.lecture?.startAt} />
+      </PlayerInfo>
+      <MatchingPopup expirationDate={matchingFormData?.expirationDate} />
+    </PageLayout>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const formId = context.query.id as string;
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery([queryKeys.coachLecture, formId], () =>
+    api.fetchCoachLectureForm(formId)
+  );
+
+  return { props: { dehydratedState: dehydrate(queryClient) } };
+};
+
+export default CoachLecturePage;

--- a/src/react-query/keys.ts
+++ b/src/react-query/keys.ts
@@ -3,6 +3,7 @@ const queryKeys = {
   lectureDetail: 'lecture-detail',
   userProfile: 'user-profile',
   coachReview: 'coach-review',
+  coachLecture: 'coach-lecture',
 };
 
 export default queryKeys;

--- a/src/types/coachLecture.ts
+++ b/src/types/coachLecture.ts
@@ -1,0 +1,38 @@
+export interface IPlayerUserMatchingForm {
+  message: string;
+  data: IPlayerUserMatchingForm;
+  timestamp: number;
+}
+
+export interface IPlayerUserForm {
+  id: number;
+  content: string;
+  lecture: {
+    id: number;
+    startAt: string;
+    endAt: string;
+    state: string;
+    reviewWritten: false;
+  };
+  user: IPlayerUser;
+  state: string;
+  expirationDate: string;
+  userImage: IUserImage;
+}
+
+export interface IPlayerUser {
+  id: number;
+  username: string;
+  ballCnt: number;
+  intro: string;
+  kakaoId: string;
+  portfolio: null;
+  identifier: string;
+  coach: true;
+  pushActive: false;
+  userImgUrl: string;
+}
+
+export interface IUserImage {
+  userImgUrl: string;
+}

--- a/src/utils/formatSchedule.ts
+++ b/src/utils/formatSchedule.ts
@@ -1,14 +1,22 @@
 import dayjs from 'dayjs';
 const week = ['일', '월', '화', '수', '목', '금', '토'];
 
-export const formatDate = (schedule: string) => {
+export const formatDate = (schedule: string, type = 'month') => {
   const time = dayjs(schedule);
 
   const month = time.get('month') + 1;
   const date = time.get('date');
   const day = time.get('day');
 
-  return month + '월 ' + date + '일 (' + week[day] + ')';
+  let formatResult = month + '월 ' + date + '일 (' + week[day] + ')';
+
+  if (type === 'year') {
+    const year = time.get('year');
+
+    formatResult = year + '년 ' + formatResult;
+  }
+
+  return formatResult;
 };
 
 export const formatTime = (schedule: string) => {


### PR DESCRIPTION
### Issue
- #81 

### 작업 내용

<img width="250" alt="스크린샷 2022-07-11 오후 8 09 50" src="https://user-images.githubusercontent.com/75570915/178252842-1007f946-2ecd-4c07-8b5b-379e2b5dbcef.png">

- 플레이어가 보낸 일정 추후 API 변경에 따라 대응 예정

### 논의 사항
- N/A

### 추가 사항
- Image 컴포넌트에 type `coach-profile` 추가
- formatDate 유틸 함수 type 매개변수 추가
