### PR TITLE
#107 fix: 클래스 상세 페이지 매칭된 사람이 없는 경우 예외처리

### DIFF
--- a/src/components/LectureDetail/MatchingButton/MatchingButton.tsx
+++ b/src/components/LectureDetail/MatchingButton/MatchingButton.tsx
@@ -40,8 +40,11 @@ const MatchingButton = () => {
   const playerRequestState = playerRequest ? playerRequest.state : 'NONE';
 
   //이미 매칭된 경우
-  const matchedLecture = lectureDetail.data.lectures.filter((lecture) => lecture.matched === true);
-  const matchedStatus = matchedLecture.filter((lecture) => lecture.matchedUser.id === userId);
+  const matchedLecture = lectureDetail.data.lectures.filter((lecture) => lecture.matched === true); //빈 배열이 리턴될 수 있음
+  const matchedStatus =
+    matchedLecture.length === 0
+      ? []
+      : matchedLecture.filter((lecture) => lecture.matchedUser.id === userId);
   const isMatched = matchedStatus.length;
 
   const handleMatchingButtonClick = () => {


### PR DESCRIPTION
### Issue
- #107

### 작업 내용
- 매칭되지 않았을 때 빈 배열이 리턴될 수 있으므로 null에 대한 id 접근하는 경우 예외처리 했습니다.
- 지금 그래도 id가 3인 클래스에 대해 오류가 뜨는데, `matched` 가 `true` 인데 불구하고 `matchedUser`가 `null`로 설정되어 있어서 그런 것 같습니다.

### 논의 사항
- 
