### PR TITLE
#115 feat: 검색 페이지 뒤로가기 버튼 브릿지 연결

### DIFF
--- a/src/components/Common/Header/Header.tsx
+++ b/src/components/Common/Header/Header.tsx
@@ -1,5 +1,4 @@
 import { PropsWithChildren } from 'react';
-import { useRouter } from 'next/router';
 import SvgIcon from '../Svg/SvgIcon';
 import * as Styled from './HeaderStyle';
 
@@ -9,12 +8,10 @@ interface IHeaderProps {
 }
 
 const Header = ({ hasBackButton, hasLine, children }: PropsWithChildren<IHeaderProps>) => {
-  const router = useRouter();
-
   return (
     <Styled.HeaderStyle hasLine={hasLine}>
       {hasBackButton && (
-        <Styled.BackButton onClick={() => router.push('/')}>
+        <Styled.BackButton onClick={() => window.Android?.navigateUp()}>
           <SvgIcon type="previous" />
         </Styled.BackButton>
       )}


### PR DESCRIPTION
### Issue
- #115 

### 작업 내용
- 검색 페이지에서 헤더 뒤로가기 버튼 누를 경우 브릿지 연결을 통해 홈 화면으로 이동

### 논의 사항
- N/A
