### PR TITLE
#122 feat: 클래스 상세페이지 CTA 버튼 가운데 정렬

### DIFF
--- a/src/components/LectureDetail/MatchingButton/MatchingButton.tsx
+++ b/src/components/LectureDetail/MatchingButton/MatchingButton.tsx
@@ -110,7 +110,7 @@ const MatchingButton = () => {
   };
 
   return (
-    <>
+    <Styled.ButtonWrapper>
       {isModalOpen && (
         <Modal _onClose={handleModalClose}>
           <Styled.ModalTextWrapper>
@@ -128,7 +128,7 @@ const MatchingButton = () => {
       >
         {handleButtonText()}
       </Styled.StyledButton>
-    </>
+    </Styled.ButtonWrapper>
   );
 };
 

--- a/src/components/LectureDetail/MatchingButton/MatchingButtonStyle.ts
+++ b/src/components/LectureDetail/MatchingButton/MatchingButtonStyle.ts
@@ -1,6 +1,12 @@
 import { Button } from '@components/Common';
 import styled from 'styled-components';
 
+export const ButtonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
 export const StyledButton = styled(Button)`
   position: fixed;
   bottom: 2.4rem;


### PR DESCRIPTION
### Issue
- #122

### 작업 내용
![image](https://user-images.githubusercontent.com/55427367/180015480-38c9e1b0-f6f3-4acd-9da3-76f94f462df4.png)

- 클래스 상세 페이지에서 화면 크기에 상관 없이 버튼이 가운데 정렬이 될 수 있게끔 수정

### 논의 사항
- 