### PR TITLE
#127 feat: 검색 페이지 검색 결과 없음 > 홈으로 가기 버튼에 안드로이드 브릿지 연결

### DIFF
--- a/src/components/Home/EmptyLectureList/EmptyLectureList.tsx
+++ b/src/components/Home/EmptyLectureList/EmptyLectureList.tsx
@@ -1,15 +1,11 @@
-import { useCallback } from 'react';
-import { useRouter } from 'next/router';
 import Image from 'next/image';
 import { Button, Typograpy } from '@components/Common';
 import * as Styled from './EmptyLectureListStyle';
 
 const EmptyLectureList = () => {
-  const router = useRouter();
-
-  const handleMoveToHomePage = useCallback(() => {
-    router.push('/');
-  }, [router]);
+  const handleMoveToHomePage = () => {
+    window.Android?.navigateUp();
+  };
 
   return (
     <Styled.EmptyLectureListContainer>


### PR DESCRIPTION
### Issue
- #127 

### 작업 내용
- 검색 페이지 검색 후 결과 없음 버튼 노출 > 클릭 후 안드로이드 브릿지 연결(navigateUp) > 홈화면으로 이동

### 논의 사항
- N/A