### PR TITLE
#145 feat: 매칭 신청 완료 후 보이는 이미지를 background-image 속성으로 수정

### DIFF
--- a/src/components/Matching/LastStep/LastStep.tsx
+++ b/src/components/Matching/LastStep/LastStep.tsx
@@ -26,10 +26,9 @@ const LastStep = () => {
         </Typograpy>
       </PageLayout>
 
-      <>
-        <Styled.MatchingSuccessImg src={`/img/matching.png`} />
+      <Styled.BackgroundImage>
         <MatchingButton _onClick={handleMatchingSuccessBtnClick}>확인</MatchingButton>
-      </>
+      </Styled.BackgroundImage>
     </>
   );
 };

--- a/src/components/Matching/LastStep/LastStep.tsx
+++ b/src/components/Matching/LastStep/LastStep.tsx
@@ -2,10 +2,13 @@ import { Typograpy } from '@components/Common';
 import { PageLayout } from '@components/Common/Layout';
 import { MatchingButton } from '../MatchingStyle';
 import React from 'react';
-import Link from 'next/link';
 import * as Styled from './LastStepStyle';
 
 const LastStep = () => {
+  const handleMatchingSuccessBtnClick = () => {
+    window.Android?.navigateUp();
+  };
+
   return (
     <>
       <PageLayout isSpacing>
@@ -25,11 +28,7 @@ const LastStep = () => {
 
       <>
         <Styled.MatchingSuccessImg src={`/img/matching.png`} />
-        <Link href="/lecture-detail/1">
-          <a>
-            <MatchingButton>확인</MatchingButton>
-          </a>
-        </Link>
+        <MatchingButton _onClick={handleMatchingSuccessBtnClick}>확인</MatchingButton>
       </>
     </>
   );

--- a/src/components/Matching/LastStep/LastStepStyle.ts
+++ b/src/components/Matching/LastStep/LastStepStyle.ts
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 
 export const BackgroundImage = styled.div`
   position: fixed;
+  display: flex;
+  justify-content: center;
   height: 100vh;
   width: 100vw;
   background-image: url('/img/matching.png');

--- a/src/components/Matching/LastStep/LastStepStyle.ts
+++ b/src/components/Matching/LastStep/LastStepStyle.ts
@@ -1,5 +1,15 @@
 import styled from 'styled-components';
 
+export const BackgroundImage = styled.div`
+  position: fixed;
+  height: 100vh;
+  width: 100vw;
+  background-image: url('/img/matching.png');
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center center;
+`;
+
 export const Title = styled.div`
   margin: 1.2rem 0 1.6rem;
 `;

--- a/src/components/Matching/SecondStep/SecondStep.tsx
+++ b/src/components/Matching/SecondStep/SecondStep.tsx
@@ -1,4 +1,4 @@
-import { Button, TextArea, Typograpy } from '@components/Common';
+import { TextArea, Typograpy } from '@components/Common';
 import { playerMatchingState } from '@recoil/matching/atoms';
 import React, { useState } from 'react';
 import { useRecoilValue } from 'recoil';
@@ -49,15 +49,18 @@ const SecondStep = () => {
         />
       </PageLayout>
       <Styled.ButtonWrapper isFocused={isFocused}>
-        <Typograpy variant="body-2" textColor="primary">
-          한번 신청한 매칭은 취소나 변경이 불가능해요.
-        </Typograpy>
-        <Typograpy variant="body-2" textColor="primary">
-          신중하게 선택해주세요.
-        </Typograpy>
-        <Button _onClick={handleNextButtonClick} disabled={content.length === 0}>
+        <Styled.AlertText>
+          <Typograpy variant="body-2" textColor="primary">
+            한번 신청한 매칭은 취소나 변경이 불가능해요.
+          </Typograpy>
+          <Typograpy variant="body-2" textColor="primary">
+            신중하게 선택해주세요.
+          </Typograpy>
+        </Styled.AlertText>
+
+        <Styled.MatchingButton _onClick={handleNextButtonClick} disabled={content.length === 0}>
           매칭 신청 완료하기
-        </Button>
+        </Styled.MatchingButton>
       </Styled.ButtonWrapper>
     </>
   );

--- a/src/components/Matching/SecondStep/SecondStepStyle.ts
+++ b/src/components/Matching/SecondStep/SecondStepStyle.ts
@@ -1,3 +1,4 @@
+import { Button } from '@components/Common';
 import styled from 'styled-components';
 
 export const TextWrapper = styled.div`
@@ -7,21 +8,25 @@ export const TextWrapper = styled.div`
   }
 `;
 
-export const Alert = styled.div`
+export const AlertText = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: fixed;
+  bottom: 12rem;
 `;
 
 export const ButtonWrapper = styled.div<{ isFocused: boolean }>`
   display: ${(props) => (props.isFocused ? 'none' : 'flex')};
   flex-direction: column;
   align-items: center;
-  position: fixed;
-  bottom: 2.4rem;
-  margin: 0 1.8rem;
-
   & > :nth-child(2) {
     margin-bottom: 2rem;
   }
+`;
+
+export const MatchingButton = styled(Button)`
+  position: fixed;
+  bottom: 2.4rem;
+  margin: 0 1.6rem;
 `;


### PR DESCRIPTION
### Issue
- #145

### 작업 내용
![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/55427367/180238882-ed0811ab-5c39-43df-96c4-cffabf1236c7.gif)

- 화면 크기에 따라 이미지가 잘려보이는 문제가 있어 background-image로 변경했습니다.
- 매칭 완료 버튼도 화면 크기에 상관 없이 가운데 정렬되게 수정했습니다.

### 논의 사항
- 
