### PR TITLE
#148 fix: 매칭신청서 키보드가 열렸을 때 버튼이 화면 위로 올라오는 문제 해결

### DIFF
--- a/src/components/Matching/SecondStep/SecondStep.tsx
+++ b/src/components/Matching/SecondStep/SecondStep.tsx
@@ -22,7 +22,7 @@ const SecondStep = () => {
   };
   const [isFocused, setIsFocused] = useState(false);
 
-  useEffect(() => {
+  const resizeViewportEvent = () => {
     window.visualViewport.addEventListener('resize', () => {
       if (window.visualViewport.height < 500) {
         //키보드가 열린 상태라고 판단
@@ -31,6 +31,13 @@ const SecondStep = () => {
         setIsFocused(false);
       }
     });
+  };
+
+  useEffect(() => {
+    resizeViewportEvent();
+    return () => {
+      window.visualViewport.removeEventListener('resize', resizeViewportEvent);
+    };
   }, [window.visualViewport.height]);
 
   return (

--- a/src/components/Matching/SecondStep/SecondStep.tsx
+++ b/src/components/Matching/SecondStep/SecondStep.tsx
@@ -1,6 +1,6 @@
 import { Button, TextArea, Typograpy } from '@components/Common';
 import { playerMatchingState } from '@recoil/matching/atoms';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import * as Styled from './SecondStepStyle';
 import { PageLayout } from '@components/Common/Layout';
@@ -20,16 +20,18 @@ const SecondStep = () => {
     const payload = { scheduleId: playerMatching.scheduleId, content: content };
     applyMatching.mutate(payload);
   };
-
   const [isFocused, setIsFocused] = useState(false);
 
-  const onFocus = () => {
-    setIsFocused(true);
-  };
-
-  const onBlur = () => {
-    setIsFocused(false);
-  };
+  useEffect(() => {
+    window.visualViewport.addEventListener('resize', () => {
+      if (window.visualViewport.height < 500) {
+        //키보드가 열린 상태라고 판단
+        setIsFocused(true);
+      } else {
+        setIsFocused(false);
+      }
+    });
+  }, [window.visualViewport.height]);
 
   return (
     <>
@@ -40,13 +42,7 @@ const SecondStep = () => {
             간단한 소개와 궁금한 내용을 적어주세요.
           </Typograpy>
         </Styled.TextWrapper>
-        <TextArea
-          onFocus={onFocus}
-          onBlur={onBlur}
-          value={content}
-          maxLength={500}
-          _onInputEntered={handleIntroductionContent}
-        />
+        <TextArea value={content} maxLength={500} _onInputEntered={handleIntroductionContent} />
       </PageLayout>
       <Styled.ButtonWrapper isFocused={isFocused}>
         <Typograpy variant="body-2" textColor="primary">


### PR DESCRIPTION
### Issue
- #148

### 작업 내용
![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/55427367/180269087-e0a1e0ba-e61c-4b5f-b5bb-ac0ad284b3fa.gif)

- 이전에는 focus, blur 이벤트에 대해 `display`를 지정해줬는데 키보드가 닫혀도 `focus` 상태인 경우의 문제점이 있었습니다.
- 그래서 아예 `viewPort`의 `innerHeight`를 계산해서 화면의 절반 이하이면 키보드가 열려있다고 판단하여 `display:none`을 주었습니다. 
- 이제 `focus` 상태여도 키보드가 닫혀있으면 버튼이 보여요~!~!~!!

### 논의 사항
- 
