### PR TITLE
#138 feat: 클래스 상세 페이지 렌더링 속도 개선

### DIFF
--- a/src/components/LectureDetail/MatchingButton/MatchingButton.tsx
+++ b/src/components/LectureDetail/MatchingButton/MatchingButton.tsx
@@ -12,7 +12,7 @@ const MatchingButton = () => {
   const user = useAuth();
   const userId = 1;
 
-  const lectureDetail = useLectureDetail(lectureId);
+  const { lectureDetail } = useLectureDetail(lectureId);
 
   //player인지 coach인지
   const userType = lectureDetail.data.coach.id === userId ? 'coach' : 'player';
@@ -49,7 +49,7 @@ const MatchingButton = () => {
   const isMatched = matchedStatus.length;
 
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const userBallCnt = user.data.user.ballCnt;
+  const userBallCnt = user?.data.user.ballCnt;
 
   const handleMatchingButtonClick = () => {
     if (userBallCnt === 0) {

--- a/src/hooks/lecture/useLectureDetail.ts
+++ b/src/hooks/lecture/useLectureDetail.ts
@@ -3,8 +3,13 @@ import { useQuery } from 'react-query';
 import queryKeys from '@react-query/keys';
 import { ILectureDetail } from '@/types/lectureDetail';
 
-const useLectureDetail = (lectureId: number): ILectureDetail => {
-  const { data: lectureDetail } = useQuery(
+interface IUseLectureDetail {
+  lectureDetail: ILectureDetail;
+  isFetching: boolean;
+}
+
+const useLectureDetail = (lectureId: number): IUseLectureDetail => {
+  const { data: lectureDetail, isFetching } = useQuery(
     [queryKeys.lectureDetail, lectureId],
     () => api.fetchLectureDetail(lectureId),
     {
@@ -12,7 +17,7 @@ const useLectureDetail = (lectureId: number): ILectureDetail => {
     }
   );
 
-  return lectureDetail;
+  return { lectureDetail, isFetching };
 };
 
 export default useLectureDetail;

--- a/src/pages/lecture-detail/[id].tsx
+++ b/src/pages/lecture-detail/[id].tsx
@@ -1,19 +1,16 @@
-import { GetServerSideProps, NextPage } from 'next';
+import { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { dehydrate, QueryClient } from 'react-query';
 import { LectureInfo, CoachProfile, Guideline, HowToUse } from '@components/LectureDetail';
 import { Typograpy } from '@components/Common';
 import { PageLayout } from '@components/Common/Layout';
 import * as Styled from '@components/LectureDetail/LectureDetailStyle';
 import useLectureDetail from '@hooks/lecture/useLectureDetail';
-import queryKeys from '@react-query/keys';
-import api from '@api';
 import MatchingButton from '@components/LectureDetail/MatchingButton/MatchingButton';
 
 const LectureDetail: NextPage = () => {
   const router = useRouter();
   const lectureId = Number(router.query.id);
-  const lectureDetail = useLectureDetail(lectureId);
+  const { lectureDetail, isFetching } = useLectureDetail(lectureId);
 
   const category = lectureDetail?.data.category;
   const topic = lectureDetail?.data.topic;
@@ -39,35 +36,25 @@ const LectureDetail: NextPage = () => {
 
   return (
     <>
-      <PageLayout isSpacing>
-        <Styled.CategoryBadge type="category">{formatCategoryName(category)}</Styled.CategoryBadge>
-        <Typograpy variant="headline-3">{topic}</Typograpy>
-        <CoachProfile coachProfile={coachProfile} />
-      </PageLayout>
-      <LectureInfo lectureInfo={lectureInfo} />
-      <PageLayout isSpacing>
-        <HowToUse />
-      </PageLayout>
-      <Guideline />
-      <MatchingButton />
+      {!isFetching && lectureDetail && (
+        <>
+          <PageLayout isSpacing>
+            <Styled.CategoryBadge type="category">
+              {formatCategoryName(category)}
+            </Styled.CategoryBadge>
+            <Typograpy variant="headline-3">{topic}</Typograpy>
+            <CoachProfile coachProfile={coachProfile} />
+          </PageLayout>
+          <LectureInfo lectureInfo={lectureInfo} />
+          <PageLayout isSpacing>
+            <HowToUse />
+          </PageLayout>
+          <Guideline />
+          <MatchingButton />
+        </>
+      )}
     </>
   );
-};
-
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { id } = context.query;
-  const queryClient = new QueryClient();
-
-  await queryClient.prefetchQuery([queryKeys.lectureDetail, Number(id)], () =>
-    api.fetchLectureDetail(Number(id))
-  );
-  await queryClient.prefetchQuery(queryKeys.auth, () => api.fetchUser());
-
-  const dehydratedState = dehydrate(queryClient);
-
-  return {
-    props: { dehydratedState: dehydratedState },
-  };
 };
 
 export default LectureDetail;

--- a/src/pages/matching/index.tsx
+++ b/src/pages/matching/index.tsx
@@ -14,7 +14,7 @@ const Matching: NextPage = () => {
   const router = useRouter();
   const lectureId = Number(router.query.id);
 
-  const lectureDetail = useLectureDetail(lectureId);
+  const { lectureDetail } = useLectureDetail(lectureId);
   const lectureSchedule = lectureDetail?.data.lectures.filter(
     (lecture) => lecture.matched === false
   );


### PR DESCRIPTION
### Issue
- #138

### 작업 내용
- 기존의 SSR에서 CSR로 바꿔 2~3초 걸리던 렌더링을 50ms로 줄였습니다. 🥺

### 논의 사항
- 안드로이드에서 스피너가 적용된걸로 알아서 일단 `isFetching`일 때 화면을 고려하지 않았습니다!
