### PR TITLE
#159 feat: 운영클래스 매칭 신청서 거절/수락 시 안드로이드 브릿지 연결

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 import { IReview } from '@/types/review';
 import { IPlayerMatchingForm } from '@/types/matching';
+import { IPatchFormStateData } from '@/types/coachLecture';
 import createAxiosWithTestToken from './customAxios';
 
 class HttpAPI {
@@ -47,6 +48,11 @@ class HttpAPI {
 
   async fetchCoachLectureForms() {
     const { data } = await createAxiosWithTestToken('coach/lecture/me').get('?state=ON_BOARD');
+    return data;
+  }
+
+  async patchCoachFormState(formId: string, state: IPatchFormStateData) {
+    const { data } = await createAxiosWithTestToken('coach/form').patch(`/${formId}/state`, state);
     return data;
   }
 

--- a/src/components/CoachLecture/FormDetail/MatchingPopup/MatchingPopup.tsx
+++ b/src/components/CoachLecture/FormDetail/MatchingPopup/MatchingPopup.tsx
@@ -5,9 +5,10 @@ import * as Styled from './MatchingPopupStyle';
 interface IMatchingPopupProps {
   expirationDate: string;
   _onModalOpen: () => void;
+  _onAccept: () => void;
 }
 
-const MatchingPopup = ({ expirationDate, _onModalOpen }: IMatchingPopupProps) => {
+const MatchingPopup = ({ expirationDate, _onModalOpen, _onAccept }: IMatchingPopupProps) => {
   return (
     <Styled.MatchingPopupContainer>
       <Styled.MatchingExpirationDate>
@@ -23,7 +24,7 @@ const MatchingPopup = ({ expirationDate, _onModalOpen }: IMatchingPopupProps) =>
         <Button variant="outlined" size="small" type="button" _onClick={_onModalOpen}>
           매칭 거절하기
         </Button>
-        <Button variant="contained" size="small" type="button">
+        <Button variant="contained" size="small" type="button" _onClick={_onAccept}>
           매칭 수락하기
         </Button>
       </Styled.MatchingButtonWrapper>

--- a/src/components/CoachLecture/FormDetail/PlayerUser/PlayerUser.tsx
+++ b/src/components/CoachLecture/FormDetail/PlayerUser/PlayerUser.tsx
@@ -11,15 +11,17 @@ const PlayerUser = memo(({ userInfo }: IPlayerUserProps) => {
   return (
     <Styled.PlayerUserContainer>
       <Styled.PlayerUserProfileWrapper>
-        <Image
-          type="form-profile"
-          src={userInfo.userImgUrl}
-          alt={`${userInfo.username}님의 프로필 이미지`}
-        />
-        <Typograpy variant="subtitle-4">{userInfo.username}</Typograpy>
+        {userInfo?.userImgUrl && (
+          <Image
+            type="form-profile"
+            src={userInfo.userImgUrl}
+            alt={`${userInfo.username}님의 프로필 이미지`}
+          />
+        )}
+        <Typograpy variant="subtitle-4">{userInfo?.username}</Typograpy>
       </Styled.PlayerUserProfileWrapper>
       <Typograpy variant="body-1" textColor="gray6B">
-        {userInfo.intro}
+        {userInfo?.intro}
       </Typograpy>
     </Styled.PlayerUserContainer>
   );

--- a/src/hooks/coachLecture/useMatchingForm.ts
+++ b/src/hooks/coachLecture/useMatchingForm.ts
@@ -1,17 +1,23 @@
-import { IPlayerUserMatchingForm } from '@/types/coachLecture';
+import { IPlayerUserForm } from '@/types/coachLecture';
 import api from '@api';
 import queryKeys from '@react-query/keys';
 import { useQuery } from 'react-query';
 
 interface IUseMatchingForm {
-  matchingFormData: IPlayerUserMatchingForm;
+  matchingFormData: IPlayerUserForm;
   isFetching: boolean;
 }
 
 const useMatchingForm = (formId: string): IUseMatchingForm => {
   const { data: matchingFormData, isFetching } = useQuery(
     [queryKeys.coachLectureFormDetail, formId],
-    () => api.fetchFormData(formId)
+    () => api.fetchFormData(formId),
+    {
+      enabled: !!formId,
+      select: (data) => {
+        return data.data;
+      },
+    }
   );
 
   return { matchingFormData, isFetching };

--- a/src/hooks/coachLecture/usePatchFormState.ts
+++ b/src/hooks/coachLecture/usePatchFormState.ts
@@ -1,0 +1,32 @@
+import { IPatchFormStateData } from '@/types/coachLecture';
+import api from '@api';
+import { useMutation } from 'react-query';
+
+const usePatchFormState = (formId: string) => {
+  const handleShowToast = (state: string) => {
+    if (state === 'ACCEPT') {
+      window.Android?.showToast('매칭 신청을 수락했습니다.\n [예정된] 페이지에서 확인해주세요!');
+    } else if (state === 'REJECT') {
+      window.Android?.showToast('매칭 신청이 거절됐습니다.');
+    }
+  };
+
+  const { mutate: patchFormState } = useMutation(
+    (state: IPatchFormStateData) => api.patchCoachFormState(formId, state),
+    {
+      onSuccess: (data) => {
+        const formState = data.data.state;
+
+        if (!formState) {
+          return;
+        }
+
+        handleShowToast(formState);
+      },
+    }
+  );
+
+  return patchFormState;
+};
+
+export default usePatchFormState;

--- a/src/hooks/coachLecture/usePatchFormState.ts
+++ b/src/hooks/coachLecture/usePatchFormState.ts
@@ -22,6 +22,7 @@ const usePatchFormState = (formId: string) => {
         }
 
         handleShowToast(formState);
+        window.Android?.navigateUp();
       },
     }
   );

--- a/src/pages/coach-lecture/form-detail/[id].tsx
+++ b/src/pages/coach-lecture/form-detail/[id].tsx
@@ -5,50 +5,68 @@ import { Modal, Typograpy } from '@components/Common';
 import { PageLayout } from '@components/Common/Layout';
 import { MatchingPopup, PlayerInfo, PlayerUser, PlayerSchedule } from '@components/CoachLecture';
 import useMatchingForm from '@hooks/coachLecture/useMatchingForm';
+import usePatchFormState from '@hooks/coachLecture/usePatchFormState';
 
 const CoachLectureFormDetailPage: NextPage = () => {
   const router = useRouter();
   const formId = router.query.id;
 
   const { matchingFormData, isFetching } = useMatchingForm(formId as string);
+  const patchFormState = usePatchFormState(formId as string);
 
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
-  const handleShowModalClick = useCallback(() => {
+  const handleModalOpen = useCallback(() => {
     setIsModalOpen((prev) => !prev);
   }, [isModalOpen]);
 
+  const handleRejectConfirmButtonClick = useCallback(() => {
+    patchFormState({ state: 'REJECT' });
+
+    setIsModalOpen(false);
+  }, [isModalOpen]);
+
+  const handleMatchingAcceptButtonClick = useCallback(() => {
+    patchFormState({ state: 'ACCEPT' });
+  }, []);
+
   return (
     <PageLayout isSpacing start={1}>
-      {isFetching && <div>Fethcing...</div>}
-      {!isFetching && (
+      <Typograpy variant="headline-3">매칭 신청서</Typograpy>
+      {isFetching ? (
+        <div>Fethcing...</div>
+      ) : (
         <>
-          <Typograpy variant="headline-3">매칭 신청서</Typograpy>
           <PlayerInfo title="플레이어 정보">
-            <PlayerUser userInfo={matchingFormData?.data.user} />
+            <PlayerUser userInfo={matchingFormData?.user} />
           </PlayerInfo>
           <PlayerInfo title="플레이어의 코멘트">
             <Typograpy variant="body-1" textColor="gray6B">
-              {matchingFormData?.data.content}
+              {matchingFormData?.content}
             </Typograpy>
           </PlayerInfo>
           <PlayerInfo title="플레이어가 보낸 일정">
             <PlayerSchedule
-              formId={matchingFormData?.data.id}
-              startAt={matchingFormData?.data.startAt}
-              endAt={matchingFormData?.data.endAt}
+              formId={matchingFormData?.id}
+              startAt={matchingFormData?.startAt}
+              endAt={matchingFormData?.endAt}
             />
           </PlayerInfo>
           <MatchingPopup
-            expirationDate={matchingFormData?.data.expirationDate}
-            _onModalOpen={handleShowModalClick}
+            expirationDate={matchingFormData?.expirationDate}
+            _onModalOpen={handleModalOpen}
+            _onAccept={handleMatchingAcceptButtonClick}
           />
-          {isModalOpen && (
-            <Modal buttonType="거절하기" _onClose={handleShowModalClick}>
-              <Typograpy variant="subtitle-3">매칭 신청을 거절하시겠어요?</Typograpy>
-            </Modal>
-          )}
         </>
+      )}
+      {isModalOpen && (
+        <Modal
+          buttonType="거절하기"
+          _onClose={handleModalOpen}
+          _onConfirm={handleRejectConfirmButtonClick}
+        >
+          <Typograpy variant="subtitle-3">매칭 신청을 거절하시겠어요?</Typograpy>
+        </Modal>
       )}
     </PageLayout>
   );

--- a/src/types/coachLecture.ts
+++ b/src/types/coachLecture.ts
@@ -67,3 +67,7 @@ export interface ICoachLectureData {
   startAt: string;
   state: string;
 }
+
+export interface IPatchFormStateData {
+  state: 'ACCEPT' | 'REJECT';
+}


### PR DESCRIPTION
### Issue
- #159 

### 작업 내용
- 매칭 신청서 거절/수락 버튼 클릭 > API 요청 > 안드로이드 브릿지 연결(토스트 팝업)

### 논의 사항
- ~~거절/수락 후 운영 클래스 매칭 중 페이지로 이동하는 안드로이드 브릿지 연결 예정 - PR Draft 상태~~
- 거절/수락 API 요청 후  성공 시 매칭 중 웹뷰 종료 브릿지(navigateUp) 연결 완료
