### PR TITLE
#167 modify: 사용자 리뷰 프로필 사진 하드코딩 되어있는 부분 수정

### DIFF
--- a/src/components/Profile/LectureReview/Review.tsx
+++ b/src/components/Profile/LectureReview/Review.tsx
@@ -37,10 +37,10 @@ const Review = ({ coachReview }: IReviewProps) => {
   return (
     <Styled.ReviewWrapper>
       <Styled.Profile>
-        <Styled.ProfileImg src={`/img/profile.png`} />
+        <Styled.ProfileImg src={coachReview.reviewee.user.userImgUrl} />
         <div>
           <Styled.NameDate>
-            <Typograpy variant="subtitle-4">{coachReview.writer.username}</Typograpy>
+            <Typograpy variant="subtitle-4">{coachReview.reviewee.user.username}</Typograpy>
             <Typograpy variant="body-2" textColor="gray8F">
               {formatWrittenDate(coachReview.writtenDate)}
             </Typograpy>


### PR DESCRIPTION
### Issue
- #167

### 작업 내용
![image](https://user-images.githubusercontent.com/55427367/180612867-bb938527-5324-4eb6-8154-60a13e90fbff.png)

- 프로필 페이지에서 사용자의 리뷰를 보여주는 부분의 프로필이 하드 코딩되어 있어 수정했습니다.

### 논의 사항
- 
