### PR TITLE
#195 feat: yarnberry를 통한 도커 이미지 빌드 시 에러 이슈 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN yarn install
 COPY . .
 RUN yarn webview build
 
+FROM node:16.14.2-alpine
 EXPOSE 3000
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,27 @@
 # node.js 압축 이미지를 설치합니다
 FROM node:16.14.2-alpine as BUILD
 
+# yarn 설치
+RUN npm install -g yarn --force
+
 # 이미지 내부 작업 경로를 설정합니다
 WORKDIR /app
 
 COPY package.json .
 COPY yarn.lock .
 
-# 필수 패키지 파일을 이미지 내부로 복사하고, npm 명령어로 설치합니다
+# 필수 패키지 파일을 이미지 내부로 복사하고, yarn 명령어로 설치합니다
 COPY package.json ./app
-RUN yarn install
+
+RUN yarn config set "strict-ssl" false -g
+RUN yarn set version berry
 
 COPY . .
+RUN rm -rf node_modules
+RUN rm -rf package-lock.json
+
+RUN yarn install
+
 RUN yarn webview build
 
 FROM node:16.14.2-alpine

--- a/packages/knowlly-landing/package.json
+++ b/packages/knowlly-landing/package.json
@@ -2,7 +2,6 @@
   "name": "knowlly-landing",
   "version": "0.1.0",
   "packageManager": "yarn@3.2.2",
-  "main": "src/index.tsx",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
### Issue
- #195

### 작업 내용
- 배포 시 발생했던 도커 파일 오류 (아래 사진 첨부) 해결
    - 도커 멀티 스테이지 추가로 오류 해결
![image (2)](https://user-images.githubusercontent.com/75570915/182023870-1bedaf09-81e9-4473-90b2-00414f7be059.png)

- 위 오류를 해결하니 빌드에서 오류 발생

```
=> ERROR [build 12/12] RUN yarn webview build                                                                                                                                         20.5s
------                                                                                                                                                                                       
 > [build 12/12] RUN yarn webview build: 

// ...생략

#17 19.43 info  - Disabled SWC as replacement for Babel because of custom Babel configuration ".babelrc" https://nextjs.org/docs/messages/swc-disabled
#17 19.95 error - Failed to load SWC binary for linux/arm64, see more info here: https://nextjs.org/docs/messages/failed-loading-swc
````

### Reference
- [Docker Dockerfile - Multi-stage build(멀티스테이지 빌드)](https://kimjingo.tistory.com/63)
- [Docker Multi Stage란?](https://nesoy.github.io/articles/2020-11/Docker-multi-stage-build)
- [docker build giving error in "yarn install"](https://github.com/docker/getting-started/issues/56)
- [Failed to load SWC binary for linux/x64 해결방법](https://velog.io/@developerjhp/Failed-to-load-SWC-binary-for-linuxx64-%ED%95%B4%EA%B2%B0%EB%B0%A9%EB%B2%95)

### 논의 사항
- 도커 파일 내부가 많이 변경되었습니다! 그래서 제가 참고했던 레퍼런스 공유드립니다!
