### PR TITLE
#196 feat: [랜딩페이지] Footer 구현

### DIFF
--- a/packages/knowlly-landing/src/components/Footer/Footer.tsx
+++ b/packages/knowlly-landing/src/components/Footer/Footer.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import * as Styled from './FooterStyle';
+
+const Footer = () => {
+  return <Styled.FooterContainer>footer</Styled.FooterContainer>;
+};
+
+export default Footer;

--- a/packages/knowlly-landing/src/components/Footer/Footer.tsx
+++ b/packages/knowlly-landing/src/components/Footer/Footer.tsx
@@ -12,8 +12,22 @@ const Footer = () => {
       <Styled.CopyrightsWrapper>
         <Styled.Copyrights>© 2022 knowlly. Copyright and rights reserved</Styled.Copyrights>
         <Styled.ServiceTermsWrapper>
-          <Styled.Copyrights>개인정보 처리방침</Styled.Copyrights>
-          <Styled.Copyrights>서비스 이용약관</Styled.Copyrights>
+          <Styled.Copyrights>
+            <a
+              target="_blank"
+              href="https://sunsetmood.notion.site/Knowlly-6293f0a979e64afbb220ebc5d0e1519f"
+            >
+              개인정보 처리방침
+            </a>
+          </Styled.Copyrights>
+          <Styled.Copyrights>
+            <a
+              target="_blank"
+              href="https://sunsetmood.notion.site/Knowlly-ad0dfa18936743729c240af88df170f0"
+            >
+              서비스 이용약관
+            </a>
+          </Styled.Copyrights>
         </Styled.ServiceTermsWrapper>
       </Styled.CopyrightsWrapper>
     </Styled.FooterContainer>

--- a/packages/knowlly-landing/src/components/Footer/Footer.tsx
+++ b/packages/knowlly-landing/src/components/Footer/Footer.tsx
@@ -2,7 +2,22 @@ import React from 'react';
 import * as Styled from './FooterStyle';
 
 const Footer = () => {
-  return <Styled.FooterContainer>footer</Styled.FooterContainer>;
+  return (
+    <Styled.FooterContainer>
+      <Styled.IntroduceTextWrapper>
+        <Styled.KnowllyText>KNOWLLY (널리)</Styled.KnowllyText>
+        <Styled.Description>Get started new try our product</Styled.Description>
+        <Styled.Description>Email: knowlly2022@gmail.com</Styled.Description>
+      </Styled.IntroduceTextWrapper>
+      <Styled.CopyrightsWrapper>
+        <Styled.Copyrights>© 2022 knowlly. Copyright and rights reserved</Styled.Copyrights>
+        <Styled.ServiceTermsWrapper>
+          <Styled.Copyrights>개인정보 처리방침</Styled.Copyrights>
+          <Styled.Copyrights>서비스 이용약관</Styled.Copyrights>
+        </Styled.ServiceTermsWrapper>
+      </Styled.CopyrightsWrapper>
+    </Styled.FooterContainer>
+  );
 };
 
 export default Footer;

--- a/packages/knowlly-landing/src/components/Footer/FooterStyle.ts
+++ b/packages/knowlly-landing/src/components/Footer/FooterStyle.ts
@@ -5,3 +5,53 @@ export const FooterContainer = styled.div`
   height: 368px;
   background-color: ${theme.color.gray['EF']};
 `;
+
+export const IntroduceTextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-left: 34.8rem;
+  padding-top: 9.9rem;
+  & > * {
+    margin-bottom: 1.6rem;
+  }
+`;
+
+export const KnowllyText = styled.span`
+  font-family: 'SUIT';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 2.2rem;
+  color: ${theme.color.primary['basic']};
+`;
+
+export const Description = styled.span`
+  font-family: 'SUIT';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 1.6rem;
+  color: ${theme.color.gray['44']};
+`;
+
+export const CopyrightsWrapper = styled.div`
+  position: absolute;
+  display: flex;
+  right: 30rem;
+
+  & > :first-child {
+    margin-right: 11.4rem;
+  }
+`;
+
+export const Copyrights = styled.p`
+  font-family: 'SUIT';
+  font-style: normal;
+  font-weight: 600;
+  font-size: 18px;
+  color: ${theme.color.gray['6B']};
+`;
+
+export const ServiceTermsWrapper = styled.div`
+  & > :first-child {
+    margin-bottom: 1rem;
+  }
+`;

--- a/packages/knowlly-landing/src/components/Footer/FooterStyle.ts
+++ b/packages/knowlly-landing/src/components/Footer/FooterStyle.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+import theme from '@styles/theme';
+
+export const FooterContainer = styled.div`
+  height: 368px;
+  background-color: ${theme.color.gray['EF']};
+`;

--- a/packages/knowlly-landing/src/pages/index.tsx
+++ b/packages/knowlly-landing/src/pages/index.tsx
@@ -1,7 +1,12 @@
+import Footer from '@components/Footer/Footer';
 import type { NextPage } from 'next';
 
 const Home: NextPage = () => {
-  return <div style={{ fontFamily: 'GmarketSansMedium' }}>폰트 테스트</div>;
+  return (
+    <>
+      <Footer />
+    </>
+  );
 };
 
 export default Home;

--- a/packages/knowlly-landing/src/styles/theme.ts
+++ b/packages/knowlly-landing/src/styles/theme.ts
@@ -1,0 +1,42 @@
+import { DefaultTheme } from 'styled-components';
+const color = {
+  /* primary */
+  primary: {
+    basic: '#FF9534',
+    dark: '#FF7A00',
+    light: '#FFF4EB',
+  },
+  /* secondary */
+  secondary: {
+    lime: '#C7E02A',
+    limeLight: '#F4F9D4',
+    limeDark: '#A5BB1B',
+    indigo: '#172351',
+    indigoLight: '#F0F4FF',
+  },
+
+  /* grayscale */
+  gray: {
+    FF: '#FFFFFF',
+    F7: '#F7F7F7',
+    EF: '#EFEFEF',
+    DD: '#DDDDDD',
+    CC: '#CCCCCC',
+    '8F': '#8F8F8F',
+    '6B': '#6B6B6B',
+    '44': '#444444',
+    '00': '#000000',
+  },
+  /* system color */
+  system: {
+    red: '#E72749', //error
+    blue: '#779DFF', //success
+    dimmed: 'rgba(0, 0, 0, 0.6)', //dimmed
+  },
+};
+
+const theme: DefaultTheme = {
+  color,
+};
+
+export default theme;

--- a/packages/knowlly-landing/tsconfig.json
+++ b/packages/knowlly-landing/tsconfig.json
@@ -1,5 +1,11 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["next.config.js", "next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.js"],
-  "exclude": ["packages/**/dist/**"]
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "paths": {
+      "@*": ["./*"],
+      "@styles/*": ["styles/*"],
+      "@components/*": ["components/*"]
+    }
+  }
 }


### PR DESCRIPTION
### Issue
- #196

### 작업 내용
![image](https://user-images.githubusercontent.com/55427367/182329580-7f4fbd5d-6653-418c-b0ce-72b4ff496825.png)

- 랜딩페이지 footer component 구현

### 논의 사항
- 폰트나 스타일을 공통으로 관리하고 싶은데 common-styles에 theme.ts 파일을 만들면 읽을 수 있는 loader가 없다는 오류가 뜨네요..ㅠ 일단 어떻게 해결해야할지 몰라서 개별 theme.ts 파일을 작성했습니다.
