### PR TITLE
#220 feat: [웹뷰] 클래스 목록 무한 스크롤 기능 수정

### DIFF
--- a/packages/knowlly-webview/src/hooks/home/useInfiniteLecture.ts
+++ b/packages/knowlly-webview/src/hooks/home/useInfiniteLecture.ts
@@ -35,7 +35,7 @@ const useInfiniteLecture = (queryKey: string, queryValue: string): IUseInfiniteL
     {
       enabled: !!queryValue,
       getNextPageParam: (lastPage) => {
-        if (lastPage.currentPage === lastPage.totalPage) {
+        if (lastPage.currentPage === lastPage.totalPage - 1) {
           return undefined;
         }
 

--- a/packages/knowlly-webview/src/pages/lecture-category/[name].tsx
+++ b/packages/knowlly-webview/src/pages/lecture-category/[name].tsx
@@ -12,7 +12,7 @@ const LectureCategoryPage: NextPage = () => {
   const router = useRouter();
   const categoryName = router.query.name;
 
-  const { lectureInfoList, fetchNextPage, isLoading, isFetching } = useInfiniteLecture(
+  const { lectureInfoList, fetchNextPage, hasNextPage, isLoading, isFetching } = useInfiniteLecture(
     '?categoryName',
     categoryName as string
   );
@@ -48,6 +48,11 @@ const LectureCategoryPage: NextPage = () => {
               <LectureList lectureInfoList={pageData} />
             </Fragment>
           ))}
+        {hasNextPage && (
+          <div ref={ref}>
+            <LoadingList isFetching />
+          </div>
+        )}
       </Section>
     </PageLayout>
   );

--- a/packages/knowlly-webview/src/pages/lecture-search/index.tsx
+++ b/packages/knowlly-webview/src/pages/lecture-search/index.tsx
@@ -9,7 +9,7 @@ import { useInView } from 'react-intersection-observer';
 const LectureSearchPage: NextPage = () => {
   const [searchVavlue, setSearchValue] = useState<string>('');
 
-  const { lectureInfoList, fetchNextPage, isFetching } = useInfiniteLecture(
+  const { lectureInfoList, fetchNextPage, hasNextPage, isFetching } = useInfiniteLecture(
     'search?keyword',
     searchVavlue
   );
@@ -35,6 +35,11 @@ const LectureSearchPage: NextPage = () => {
               <LectureList lectureInfoList={pageData} />
             </Fragment>
           ))}
+        {hasNextPage && (
+          <div ref={ref}>
+            <LoadingList isFetching />
+          </div>
+        )}
       </Section>
     </PageLayout>
   );


### PR DESCRIPTION
### Issue
- #220 

### 작업 내용
- 마지막 클래스 카드를 보여줄 경우 다시 클래스 목록을 불러오기 위해 옵저버 역할을 하는 `div` 태그 추가
- `div` 태그에 `useInview` ref 연결

### 논의 사항
- N/A
